### PR TITLE
feat: Allow remote connection to blender

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,12 @@ For Windows users, go to Settings > MCP > Add Server, add a new server with the 
 }
 ```
 
+### Remote Blender Access
+
+If connecting to blender on a remote machine pass the host name to the blender mcp server using the environmental variable BLENDER_SERVER_HOST.
+
+Ensure in the blender addon configuration you have selected "All interfaces" before starting the connection.
+
 [Cursor setup video](https://www.youtube.com/watch?v=wgWsJshecac)
 
 **⚠️ Only run one instance of the MCP server (either on Cursor or Claude Desktop), not both**

--- a/addon.py
+++ b/addon.py
@@ -1386,6 +1386,7 @@ class BLENDERMCP_PT_Panel(bpy.types.Panel):
         scene = context.scene
         
         layout.prop(scene, "blendermcp_port")
+        layout.prop(scene, "blendermcp_host_all_interfaces")
         layout.prop(scene, "blendermcp_use_polyhaven", text="Use assets from Poly Haven")
 
         layout.prop(scene, "blendermcp_use_hyper3d", text="Use Hyper3D Rodin 3D model generation")
@@ -1419,10 +1420,14 @@ class BLENDERMCP_OT_StartServer(bpy.types.Operator):
     
     def execute(self, context):
         scene = context.scene
+
+        host = 'localhost'
+        if scene.blendermcp_host_all_interfaces:
+            host = '0.0.0.0'
         
         # Create a new server instance
         if not hasattr(bpy.types, "blendermcp_server") or not bpy.types.blendermcp_server:
-            bpy.types.blendermcp_server = BlenderMCPServer(port=scene.blendermcp_port)
+            bpy.types.blendermcp_server = BlenderMCPServer(host=host, port=scene.blendermcp_port)
         
         # Start the server
         bpy.types.blendermcp_server.start()
@@ -1456,6 +1461,12 @@ def register():
         default=9876,
         min=1024,
         max=65535
+    )
+    
+    bpy.types.Scene.blendermcp_host_all_interfaces = bpy.props.BoolProperty(
+        name="All interfaces",
+        description="Serve on all interfaces to allow remote connection",
+        default=False
     )
     
     bpy.types.Scene.blendermcp_server_running = bpy.props.BoolProperty(
@@ -1511,6 +1522,7 @@ def unregister():
     bpy.utils.unregister_class(BLENDERMCP_OT_StopServer)
     
     del bpy.types.Scene.blendermcp_port
+    del bpy.types.Scene.blendermcp_host_all_interfaces
     del bpy.types.Scene.blendermcp_server_running
     del bpy.types.Scene.blendermcp_use_polyhaven
     del bpy.types.Scene.blendermcp_use_hyper3d

--- a/src/blender_mcp/server.py
+++ b/src/blender_mcp/server.py
@@ -17,6 +17,9 @@ logging.basicConfig(level=logging.INFO,
                     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 logger = logging.getLogger("BlenderMCPServer")
 
+blender_host = os.getenv("BLENDER_SERVER_HOST", "localhost")
+blender_port = 9876
+
 @dataclass
 class BlenderConnection:
     host: str
@@ -225,7 +228,7 @@ def get_blender_connection():
     
     # Create a new connection if needed
     if _blender_connection is None:
-        _blender_connection = BlenderConnection(host="localhost", port=9876)
+        _blender_connection = BlenderConnection(host=blender_host, port=blender_port)
         if not _blender_connection.connect():
             logger.error("Failed to connect to Blender")
             _blender_connection = None


### PR DESCRIPTION
### **User description**
This change allows connection to blender on a remote machine in the cases where your MCP server is not running on the same machine as blender.

This changes adds:
* a "All interfaces" option in the blender addon, with it selected the server is exposed on 0.0.0.0 instead of localhost
* an environmental variable BLENDER_SERVER_HOST in the MCP server where you can set the host name of the machine running blender.


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Added support for remote Blender connections via server host configuration
  - New "All interfaces" option in Blender add-on UI
  - Server can bind to 0.0.0.0 for remote access
  - MCP server can use BLENDER_SERVER_HOST environment variable

- Updated documentation for remote access setup


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>addon.py</strong><dd><code>Add UI and logic for remote server binding option</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

addon.py

<li>Added "All interfaces" checkbox to Blender add-on UI for server <br>binding<br> <li> Server now binds to 0.0.0.0 if option is selected, otherwise localhost<br> <li> Registered and unregistered new property for interface selection


</details>


  </td>
  <td><a href="https://github.com/ahujasid/blender-mcp/pull/115/files#diff-a00fabecb6c13a84bae446368347ab0da61ce323e65e01afdbbbb9639cd17605">+13/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>server.py</strong><dd><code>Support configurable Blender host via environment variable</code></dd></summary>
<hr>

src/blender_mcp/server.py

<li>Added support for BLENDER_SERVER_HOST environment variable to set <br>Blender host<br> <li> Default host remains localhost if variable is unset<br> <li> Connection logic uses configurable host value


</details>


  </td>
  <td><a href="https://github.com/ahujasid/blender-mcp/pull/115/files#diff-9d7e3cb4a2dd22ba7b1b7a62a2457e95ae4d0924bcd9a1cd5840f510086433d3">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document remote Blender access configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<li>Documented remote Blender access setup<br> <li> Added instructions for using BLENDER_SERVER_HOST and UI option


</details>


  </td>
  <td><a href="https://github.com/ahujasid/blender-mcp/pull/115/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added an option in the user interface to allow the Blender MCP server to bind to all network interfaces, enabling remote connections.
- **Documentation**
	- Updated the README with instructions for connecting to a remote Blender MCP server, including environment variable setup and addon configuration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->