### PR TITLE
Fix Hyper3D image upload decoding and URL validation

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -1188,7 +1188,7 @@ class BlenderMCPServer:
                 images = []
             """Call Rodin API, get the job uuid and subscription key"""
             files = [
-                *[("images", (f"{i:04d}{img_suffix}", img)) for i, (img_suffix, img) in enumerate(images)],
+                *[("images", (f"{i:04d}{img_suffix}", base64.b64decode(img))) for i, (img_suffix, img) in enumerate(images)],
                 ("tier", (None, "Sketch")),
                 ("mesh_mode", (None, "Raw")),
             ]

--- a/src/blender_mcp/server.py
+++ b/src/blender_mcp/server.py
@@ -27,6 +27,7 @@ DEFAULT_HOST = "localhost"
 DEFAULT_PORT = 9876
 
 def _is_valid_http_url(value: str) -> bool:
+    """Return True when value is an absolute HTTP(S) URL with a host."""
     parsed = urlparse(value)
     return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
 

--- a/src/blender_mcp/server.py
+++ b/src/blender_mcp/server.py
@@ -26,6 +26,10 @@ logger = logging.getLogger("BlenderMCPServer")
 DEFAULT_HOST = "localhost"
 DEFAULT_PORT = 9876
 
+def _is_valid_http_url(value: str) -> bool:
+    parsed = urlparse(value)
+    return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
+
 @dataclass
 class BlenderConnection:
     host: str
@@ -874,7 +878,7 @@ def generate_hyper3d_model_via_images(
                     (Path(path).suffix, base64.b64encode(f.read()).decode("ascii"))
                 )
     elif input_image_urls is not None:
-        if not all(urlparse(i) for i in input_image_urls):
+        if not all(_is_valid_http_url(i) for i in input_image_urls):
             return "Error: not all image URLs are valid!"
         images = input_image_urls.copy()
     try:

--- a/src/blender_mcp/server.py
+++ b/src/blender_mcp/server.py
@@ -874,7 +874,7 @@ def generate_hyper3d_model_via_images(
                     (Path(path).suffix, base64.b64encode(f.read()).decode("ascii"))
                 )
     elif input_image_urls is not None:
-        if not all(urlparse(i) for i in input_image_paths):
+        if not all(urlparse(i) for i in input_image_urls):
             return "Error: not all image URLs are valid!"
         images = input_image_urls.copy()
     try:

--- a/src/blender_mcp/server.py
+++ b/src/blender_mcp/server.py
@@ -799,6 +799,7 @@ def download_sketchfab_model(
         return f"Error downloading Sketchfab model: {str(e)}"
 
 def _process_bbox(original_bbox: list[float] | list[int] | None) -> list[int] | None:
+    """Normalize bbox ratios to integer percentages for the Hyper3D API."""
     if original_bbox is None:
         return None
     if all(isinstance(i, int) for i in original_bbox):


### PR DESCRIPTION
  ## Summary

  This PR fixes two bugs in the Hyper3D generation flow.

  1. In `MAIN_SITE` mode, image data was base64-encoded in the MCP server for transport to the
  Blender addon, but the addon forwarded that base64 text directly to
  `requests.post(files=...)` instead of decoding it back to raw bytes. This caused invalid
  multipart image uploads.

  2. In the `input_image_urls` branch of `generate_hyper3d_model_via_images`, the code
  validated `input_image_paths` instead of `input_image_urls`. When the URL branch was used,
  this could raise a `TypeError` instead of validating the provided URLs.

  ## Changes

  - Decode image payloads with `base64.b64decode(...)` before sending multipart files in
  `create_rodin_job_main_site`
  - Validate `input_image_urls` in the URL-input branch of `generate_hyper3d_model_via_images`
  - Add a bug report note documenting both issues

  ## Impact

  - Fixes image-based Hyper3D generation in `MAIN_SITE` mode
  - Fixes URL-based Hyper3D input validation in `FAL_AI` mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Image uploads now send raw image bytes instead of encoded text, improving upload reliability and compatibility.
  * Image URL validation corrected to properly detect invalid HTTP/HTTPS image URLs and return an error when any are invalid.

* **Chores**
  * Minor formatting and newline adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->