### PR TITLE
fix: use input_image_urls instead of input_image_paths in URL validation

### DIFF
--- a/src/blender_mcp/server.py
+++ b/src/blender_mcp/server.py
@@ -874,7 +874,7 @@ def generate_hyper3d_model_via_images(
                     (Path(path).suffix, base64.b64encode(f.read()).decode("ascii"))
                 )
     elif input_image_urls is not None:
-        if not all(urlparse(i) for i in input_image_paths):
+        if not all(urlparse(i) for i in input_image_urls):
             return "Error: not all image URLs are valid!"
         images = input_image_urls.copy()
     try:

--- a/src/blender_mcp/server.py
+++ b/src/blender_mcp/server.py
@@ -874,7 +874,7 @@ def generate_hyper3d_model_via_images(
                     (Path(path).suffix, base64.b64encode(f.read()).decode("ascii"))
                 )
     elif input_image_urls is not None:
-        if not all(urlparse(i) for i in input_image_urls):
+        if not all(urlparse(i).scheme in {"http", "https"} and bool(urlparse(i).netloc) for i in input_image_urls):
             return "Error: not all image URLs are valid!"
         images = input_image_urls.copy()
     try:


### PR DESCRIPTION
Closes #221

## Problem

In `generate_hyper3d_model_via_images`, the URL validation branch iterates over `input_image_paths` instead of `input_image_urls`. At that point `input_image_paths` is `None`, causing a `TypeError: 'NoneType' object is not iterable` for all callers using Hyper3D Rodin FAL_AI mode.\n\n## Fix\n\nChange `for i in input_image_paths` to `for i in input_image_urls` on line 877 of `src/blender_mcp/server.py`.\n\nSigned-off-by: cocoon <54054995+kuishou68@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected URL validation when generating 3D models from images so the system now properly validates each provided image URL (requiring http/https and a host), preventing invalid URLs from being accepted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->