### PR TITLE
fix: distinguish Blender addon errors from transport failures

### DIFF
--- a/src/blender_mcp/server.py
+++ b/src/blender_mcp/server.py
@@ -26,6 +26,16 @@ logger = logging.getLogger("BlenderMCPServer")
 DEFAULT_HOST = "localhost"
 DEFAULT_PORT = 9876
 
+
+class BlenderCommandError(Exception):
+    """Raised when the Blender addon reports an error for a command.
+
+    Distinguished from generic Exception so callers can tell a Python
+    exception inside executed code (socket healthy, addon responsive)
+    from a real transport failure (socket dead, addon unreachable).
+    """
+
+
 @dataclass
 class BlenderConnection:
     host: str
@@ -143,9 +153,13 @@ class BlenderConnection:
             
             if response.get("status") == "error":
                 logger.error(f"Blender error: {response.get('message')}")
-                raise Exception(response.get("message", "Unknown error from Blender"))
-            
+                raise BlenderCommandError(response.get("message", "Unknown error from Blender"))
+
             return response.get("result", {})
+        except BlenderCommandError:
+            # Addon responded with an error status — socket is healthy,
+            # don't wrap as a communication error and don't drop the socket.
+            raise
         except socket.timeout:
             logger.error("Socket timeout while waiting for response from Blender")
             # Don't try to reconnect here - let the get_blender_connection handle reconnection
@@ -342,9 +356,19 @@ def execute_blender_code(ctx: Context, code: str) -> str:
         blender = get_blender_connection()
         result = blender.send_command("execute_code", {"code": code})
         return f"Code executed successfully: {result.get('result', '')}"
+    except BlenderCommandError as e:
+        # A Python exception inside the executed code round-tripped cleanly.
+        # The addon prefixes these with "Code execution error: "; strip it so
+        # the user sees the underlying exception without two layers of framing.
+        msg = str(e)
+        prefix = "Code execution error: "
+        if msg.startswith(prefix):
+            msg = msg[len(prefix):]
+        logger.info(f"Blender Python error: {msg}")
+        return f"Blender Python error: {msg}"
     except Exception as e:
-        logger.error(f"Error executing code: {str(e)}")
-        return f"Error executing code: {str(e)}"
+        logger.error(f"Communication error executing code: {str(e)}")
+        return f"Communication error: {str(e)}"
 
 @telemetry_tool("get_polyhaven_categories")
 @mcp.tool()


### PR DESCRIPTION
## Summary

When user Python raises inside `execute_blender_code`, the server currently returns:

```
Error executing code: Communication error with Blender: Code execution error: <real exception>
```

The `Communication error` prefix implies a transport/socket failure, but the socket is healthy — it's a normal Python exception that round-tripped successfully through the addon. First-instinct response is to restart Blender / reconnect the MCP, which wastes triage time. The socket is *also* dropped unnecessarily by the catch-all, so every user-code error forces a reconnect on the next call.

## Fix

- New `BlenderCommandError` exception class for errors the addon reported via `{"status": "error"}` (socket healthy, addon responsive).
- `BlenderConnection.send_command` raises `BlenderCommandError` instead of a generic `Exception`, and re-raises it through the catch-all without wrapping and without nulling `self.sock`.
- `execute_blender_code` catches `BlenderCommandError` specifically and returns `Blender Python error: <exc>` with the addon's duplicate `Code execution error: ` prefix stripped. True transport failures still return `Communication error: ...`.

All other `@mcp.tool` endpoints already have a generic `except Exception as e:` catcher and inherit a cleaner error message for free — no changes needed in their bodies.

## Before / after

Before (Python `NameError` in executed code):
```
Error executing code: Communication error with Blender: Code execution error: name 'foo' is not defined
```

After:
```
Blender Python error: name 'foo' is not defined
```

Before (socket dies mid-call):
```
Error executing code: Communication error with Blender: [WinError 10054] ...
```

After:
```
Communication error: [WinError 10054] ...
```

## Test plan

- [ ] With the patched server installed (`uv pip install -e .`), call `execute_blender_code` with code that raises (`raise ValueError('x')`) → response starts with `Blender Python error:`.
- [ ] Kill the addon mid-call → response starts with `Communication error:`.
- [ ] Confirm the socket is NOT nulled for a Python exception: call `execute_blender_code` with failing code, then immediately call a succeeding command — should reuse the same socket (no reconnect log).
- [ ] Other tools (`get_object_info` on a missing object, `set_texture` with a bad slot) return the addon's error message without a `Communication error with Blender:` prefix.

Filed from downstream tracking as issue `Blender-ntr` in a workspace accumulating blender-mcp fixes; happy to follow up with the rest of the queue (version exposure, visual-verification tooling, material-slot helpers) if there's interest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling and messaging for Blender Python code execution failures
  * Improved error diagnostics with clearer distinction between Blender execution errors and communication failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->