### PR TITLE
feat: expose Blender version in get_scene_info payload

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -278,6 +278,11 @@ class BlenderMCPServer:
                 "object_count": len(bpy.context.scene.objects),
                 "objects": [],
                 "materials_count": len(bpy.data.materials),
+                # Blender version is exposed so callers can branch on
+                # version-sensitive API surface (enum values, operator args,
+                # removed/renamed nodes) rather than guessing.
+                "blender_version": list(bpy.app.version),
+                "blender_version_string": bpy.app.version_string,
             }
 
             # Collect minimal object information (limit to first 10 objects)

--- a/src/blender_mcp/server.py
+++ b/src/blender_mcp/server.py
@@ -254,7 +254,14 @@ def get_blender_connection():
 @telemetry_tool("get_scene_info")
 @mcp.tool()
 def get_scene_info(ctx: Context) -> str:
-    """Get detailed information about the current Blender scene"""
+    """Get detailed information about the current Blender scene.
+
+    The response includes `blender_version` (e.g. [5, 1, 0]) and
+    `blender_version_string` (e.g. "5.1.0 Release"). Inspect these
+    before emitting code that touches version-sensitive surface:
+    shader/modifier enums, operator arguments, compositor node types,
+    and renamed APIs all drift between major versions.
+    """
     try:
         blender = get_blender_connection()
         result = blender.send_command("get_scene_info")


### PR DESCRIPTION
## Summary

Blender's Python API drifts between major versions and callers to the MCP have no way to detect which version they're targeting. Examples hit in the wild during recent testing on Blender 5.1:

- `ShaderNodeTexSky.sky_type='NISHITA'` — removed in 5.x (was valid 2.90–4.x). Current valid enums: `SINGLE_SCATTERING | MULTIPLE_SCATTERING | PREETHAM | HOSEK_WILKIE`.
- `scene.node_tree` — renamed to `scene.compositing_node_group` in 5.1 and no longer auto-created.
- `CompositorNodeMixRGB`, `CompositorNodeComposite` — removed in 5.x, replaced by `ShaderNodeMix(data_type='RGBA')` and `NodeGroupOutput`.
- `DistortedNoiseTexture.noise_intensity` — removed in 5.x.

Each of these surfaces as a runtime `AttributeError` or `TypeError` because the caller (human or model) emits code against an assumed-current API without a way to check.

## Fix

Two additional fields on the `get_scene_info` response:

- `blender_version` — list of ints, e.g. `[5, 1, 0]` (from `bpy.app.version`).
- `blender_version_string` — e.g. `"5.1.0 Release"` (from `bpy.app.version_string`).

Chose to extend `get_scene_info` rather than add a dedicated `get_blender_version` tool:

- No new tool registration, no new handler in the addon's dispatch dict.
- Every existing caller that already inspects scene state picks up the fields automatically.
- Server-side docstring updated so models/agents are prompted to branch on these fields before emitting version-sensitive code.

Tradeoff: callers that only want the version pull a full scene dump. For this use case that's fine — scene dumps are small and the MCP has no high-frequency version-polling pattern.

## Test plan

- [ ] Call `get_scene_info` on Blender 5.1 — response contains `"blender_version": [5, 1, 0]` and `"blender_version_string": "5.1.0 Release"`.
- [ ] Call on an earlier 4.x or 3.x — reports the expected version string with no errors.
- [ ] Response is still valid JSON (no tuple leakage).

Downstream tracking bead: `Blender-tci`. Related observed-in-the-wild cases filed as `Blender-t5h` (compositor API rename), `Blender-48v` (DistortedNoiseTexture), which this unblocks — callers can now emit version-guarded code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scene information response now includes Blender version details (numeric version list and version string).

* **Documentation**
  * Updated guidance recommending users check version information before using version-specific APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->