### PR TITLE
feat: add visual-verification tools (verify_object_grounded + ortho-diag screenshot)

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -207,6 +207,7 @@ class BlenderMCPServer:
             "get_scene_info": self.get_scene_info,
             "get_object_info": self.get_object_info,
             "get_viewport_screenshot": self.get_viewport_screenshot,
+            "verify_object_grounded": self.verify_object_grounded,
             "execute_code": self.execute_code,
             "get_telemetry_consent": self.get_telemetry_consent,
             "get_polyhaven_status": self.get_polyhaven_status,
@@ -361,20 +362,40 @@ class BlenderMCPServer:
 
         return obj_info
 
-    def get_viewport_screenshot(self, max_size=800, filepath=None, format="png"):
+    def get_viewport_screenshot(self, max_size=800, filepath=None, format="png",
+                                target_object=None, view="front",
+                                distance_factor=2.5, ortho_padding=1.25):
         """
-        Capture a screenshot of the current 3D viewport and save it to the specified path.
+        Capture a screenshot of the current 3D viewport OR a clean orthographic
+        diagnostic render of a specific object.
+
+        Default path (target_object=None) screenshots the active 3D viewport,
+        preserving overlays and the user's view. If target_object is provided,
+        creates a temporary orthographic camera framed on that object from
+        the named view and renders a clean image — useful for verifying
+        grounding, alignment, and material claims that position math alone
+        cannot confirm (asymmetric mesh edits, Displace modifiers, etc.).
 
         Parameters:
         - max_size: Maximum size in pixels for the largest dimension of the image
         - filepath: Path where to save the screenshot file
         - format: Image format (png, jpg, etc.)
+        - target_object: If set, render an orthographic view of this object
+        - view: Camera direction (front, back, left, right, top, bottom)
+        - distance_factor: Camera distance as multiple of object's largest dimension
+        - ortho_padding: Ortho scale multiplier (>1 leaves margin around the object)
 
         Returns success/error status
         """
         try:
             if not filepath:
                 return {"error": "No filepath provided"}
+
+            if target_object is not None:
+                return self._render_ortho_diag(
+                    target_object, filepath, max_size, format,
+                    view, distance_factor, ortho_padding,
+                )
 
             # Find the active 3D viewport
             area = None
@@ -417,6 +438,190 @@ class BlenderMCPServer:
 
         except Exception as e:
             return {"error": str(e)}
+
+    def _render_ortho_diag(self, target_name, filepath, max_size, format,
+                           view, distance_factor, ortho_padding):
+        """Render a clean orthographic view of target_name from `view`."""
+        import math
+
+        scene = bpy.context.scene
+        obj = scene.objects.get(target_name)
+        if obj is None:
+            return {"error": f"Object '{target_name}' not found in scene"}
+
+        depsgraph = bpy.context.evaluated_depsgraph_get()
+        eval_obj = obj.evaluated_get(depsgraph)
+        mw = eval_obj.matrix_world
+        corners = [mw @ mathutils.Vector(c) for c in eval_obj.bound_box]
+        xs = [c.x for c in corners]
+        ys = [c.y for c in corners]
+        zs = [c.z for c in corners]
+        center = mathutils.Vector((
+            (min(xs) + max(xs)) / 2,
+            (min(ys) + max(ys)) / 2,
+            (min(zs) + max(zs)) / 2,
+        ))
+        size_x = max(xs) - min(xs)
+        size_y = max(ys) - min(ys)
+        size_z = max(zs) - min(zs)
+        max_dim = max(size_x, size_y, size_z, 0.01)
+
+        # (offset_direction_from_center, camera_euler_rotation)
+        view_configs = {
+            "front":  (mathutils.Vector((0, -1, 0)), (math.pi / 2, 0, 0)),
+            "back":   (mathutils.Vector((0, 1, 0)),  (math.pi / 2, 0, math.pi)),
+            "right":  (mathutils.Vector((1, 0, 0)),  (math.pi / 2, 0, math.pi / 2)),
+            "left":   (mathutils.Vector((-1, 0, 0)), (math.pi / 2, 0, -math.pi / 2)),
+            "top":    (mathutils.Vector((0, 0, 1)),  (0, 0, 0)),
+            "bottom": (mathutils.Vector((0, 0, -1)), (math.pi, 0, 0)),
+        }
+        if view not in view_configs:
+            return {"error": f"Unknown view '{view}'. Choose from: {sorted(view_configs)}"}
+
+        offset_dir, rotation_euler = view_configs[view]
+        cam_distance = max_dim * distance_factor
+        cam_pos = center + offset_dir * cam_distance
+
+        cam_data = bpy.data.cameras.new("_MCPDiagCam")
+        cam_data.type = 'ORTHO'
+        cam_data.ortho_scale = max_dim * ortho_padding
+        cam_data.clip_start = 0.01
+        cam_data.clip_end = cam_distance * 4 + max_dim * 4
+        cam_obj = bpy.data.objects.new("_MCPDiagCam", cam_data)
+        cam_obj.location = cam_pos
+        cam_obj.rotation_euler = rotation_euler
+        scene.collection.objects.link(cam_obj)
+
+        # Save render state, render, restore
+        prev_camera = scene.camera
+        prev_res_x = scene.render.resolution_x
+        prev_res_y = scene.render.resolution_y
+        prev_filepath = scene.render.filepath
+        prev_file_format = scene.render.image_settings.file_format
+        width = height = 0
+        render_error = None
+        try:
+            scene.camera = cam_obj
+            scene.render.resolution_x = max_size
+            scene.render.resolution_y = max_size
+            scene.render.filepath = filepath
+            scene.render.image_settings.file_format = format.upper()
+            bpy.ops.render.render(write_still=True)
+
+            if os.path.exists(filepath):
+                img = bpy.data.images.load(filepath)
+                width, height = img.size
+                bpy.data.images.remove(img)
+            else:
+                render_error = "Render file was not created"
+        except Exception as e:
+            render_error = str(e)
+        finally:
+            scene.camera = prev_camera
+            scene.render.resolution_x = prev_res_x
+            scene.render.resolution_y = prev_res_y
+            scene.render.filepath = prev_filepath
+            scene.render.image_settings.file_format = prev_file_format
+            bpy.data.objects.remove(cam_obj, do_unlink=True)
+            bpy.data.cameras.remove(cam_data, do_unlink=True)
+
+        if render_error:
+            return {"error": render_error}
+
+        return {
+            "success": True,
+            "width": width,
+            "height": height,
+            "filepath": filepath,
+            "target": target_name,
+            "view": view,
+        }
+
+    def verify_object_grounded(self, object_name, ground_name,
+                               slice_height=1.0, max_samples=500):
+        """Measure the vertical gap between an object's base and a ground mesh.
+
+        Samples vertices from the object's lower slice (z <= zmin + slice_height)
+        in world space and raycasts straight down onto the ground's evaluated
+        mesh. Returns min/max/median/mean gaps (positive = floating above,
+        negative = intersecting). Uses evaluated geometry so Displace modifiers
+        on the ground and shape keys / armatures on the object are honored.
+        """
+        from mathutils.bvhtree import BVHTree
+
+        scene = bpy.context.scene
+        obj = scene.objects.get(object_name)
+        ground = scene.objects.get(ground_name)
+        if obj is None:
+            return {"error": f"Object '{object_name}' not found"}
+        if ground is None:
+            return {"error": f"Ground object '{ground_name}' not found"}
+        if obj.type != 'MESH':
+            return {"error": f"Object '{object_name}' is not a mesh (type={obj.type})"}
+        if ground.type != 'MESH':
+            return {"error": f"Ground '{ground_name}' is not a mesh (type={ground.type})"}
+
+        depsgraph = bpy.context.evaluated_depsgraph_get()
+        obj_eval = obj.evaluated_get(depsgraph)
+        ground_eval = ground.evaluated_get(depsgraph)
+        bvh = BVHTree.FromObject(ground_eval, depsgraph)
+
+        obj_mw = obj_eval.matrix_world
+        world_verts = [obj_mw @ v.co for v in obj_eval.data.vertices]
+        if not world_verts:
+            return {"error": f"Object '{object_name}' has no vertices"}
+
+        zmin = min(v.z for v in world_verts)
+        slice_verts = [v for v in world_verts if v.z <= zmin + slice_height]
+        if len(slice_verts) > max_samples:
+            step = max(1, len(slice_verts) // max_samples)
+            slice_verts = slice_verts[::step]
+
+        gaps = []
+        missed = 0
+        for v in slice_verts:
+            origin = mathutils.Vector((v.x, v.y, v.z + 1000.0))
+            direction = mathutils.Vector((0, 0, -1))
+            hit_loc, hit_normal, hit_idx, hit_dist = bvh.ray_cast(origin, direction)
+            if hit_loc is None:
+                missed += 1
+                continue
+            gaps.append(v.z - hit_loc.z)
+
+        if not gaps:
+            return {
+                "error": "No ground samples hit — object may be outside ground bounds or ground mesh is empty",
+                "samples_tested": len(slice_verts),
+                "samples_missed": missed,
+            }
+
+        gaps_sorted = sorted(gaps)
+        median_gap = gaps_sorted[len(gaps_sorted) // 2]
+        min_gap = min(gaps)
+        max_gap = max(gaps)
+
+        if min_gap < -0.01 and max_gap > 0.01:
+            hint = "mixed: tilted or uneven ground; base partly above and partly below"
+        elif max_gap < 0.01:
+            hint = "grounded or intersecting (no samples above ground)"
+        elif min_gap > 0.05:
+            hint = f"floating: closest sample is {min_gap:.3f}m above ground"
+        else:
+            hint = "close to ground"
+
+        return {
+            "object_name": object_name,
+            "ground_name": ground_name,
+            "samples_tested": len(slice_verts),
+            "samples_hit": len(gaps),
+            "samples_missed": missed,
+            "min_gap": round(min_gap, 4),
+            "max_gap": round(max_gap, 4),
+            "median_gap": round(median_gap, 4),
+            "mean_gap": round(sum(gaps) / len(gaps), 4),
+            "slice_height": slice_height,
+            "hint": hint,
+        }
 
     def execute_code(self, code):
         """Execute arbitrary Blender Python code"""

--- a/src/blender_mcp/server.py
+++ b/src/blender_mcp/server.py
@@ -286,28 +286,59 @@ def get_object_info(ctx: Context, object_name: str) -> str:
 
 @telemetry_tool("get_viewport_screenshot")
 @mcp.tool()
-def get_viewport_screenshot(ctx: Context, max_size: int = 800) -> Image:
+def get_viewport_screenshot(
+    ctx: Context,
+    max_size: int = 800,
+    target_object: str = None,
+    view: str = "front",
+    distance_factor: float = 2.5,
+    ortho_padding: float = 1.25,
+) -> Image:
     """
-    Capture a screenshot of the current Blender 3D viewport.
-    
+    Capture a screenshot of the current Blender 3D viewport OR a clean
+    orthographic diagnostic render of a specific object.
+
+    Default behavior (target_object=None): screenshots the active viewport
+    as the user sees it, including overlays and the user's camera.
+
+    If `target_object` is provided: creates a temporary orthographic camera
+    framed on that object from the named `view` direction and renders a
+    clean image. Use this to verify visual claims — grounding, alignment,
+    material changes — without relying on position math that lies after
+    asymmetric mesh edits or Displace modifiers.
+
     Parameters:
-    - max_size: Maximum size in pixels for the largest dimension (default: 800)
-    
-    Returns the screenshot as an Image.
+    - max_size: Maximum pixels for the longest dimension (default 800).
+    - target_object: If set, render an orthographic view of this object instead
+      of a viewport screenshot.
+    - view: Axis direction for the diagnostic view. One of:
+      front, back, left, right, top, bottom. Default 'front'.
+    - distance_factor: Camera distance as a multiple of the object's largest
+      world-bbox dimension (default 2.5).
+    - ortho_padding: Ortho scale multiplier (default 1.25, >1 leaves margin).
+
+    Returns the screenshot/render as an Image.
     """
     try:
         blender = get_blender_connection()
-        
+
         # Create temp file path
         temp_dir = tempfile.gettempdir()
         temp_path = os.path.join(temp_dir, f"blender_screenshot_{os.getpid()}.png")
-        
-        result = blender.send_command("get_viewport_screenshot", {
+
+        params = {
             "max_size": max_size,
             "filepath": temp_path,
-            "format": "png"
-        })
-        
+            "format": "png",
+        }
+        if target_object is not None:
+            params["target_object"] = target_object
+            params["view"] = view
+            params["distance_factor"] = distance_factor
+            params["ortho_padding"] = ortho_padding
+
+        result = blender.send_command("get_viewport_screenshot", params)
+
         if "error" in result:
             raise Exception(result["error"])
         
@@ -326,6 +357,51 @@ def get_viewport_screenshot(ctx: Context, max_size: int = 800) -> Image:
     except Exception as e:
         logger.error(f"Error capturing screenshot: {str(e)}")
         raise Exception(f"Screenshot failed: {str(e)}")
+
+
+@telemetry_tool("verify_object_grounded")
+@mcp.tool()
+def verify_object_grounded(
+    ctx: Context,
+    object_name: str,
+    ground_name: str,
+    slice_height: float = 1.0,
+    max_samples: int = 500,
+) -> str:
+    """
+    Measure the vertical gap between an object's base and a ground mesh.
+
+    Samples vertices from the object's lower slice (world z within
+    `slice_height` of the object's lowest vertex) and raycasts straight down
+    onto the ground's evaluated mesh. Returns a JSON summary with min, max,
+    median, and mean gap in meters. Positive = above ground, negative =
+    intersecting. Uses evaluated geometry, so Displace modifiers on the
+    ground and armature/shape-key deformation on the object are honored.
+
+    Use this to verify grounding instead of relying on `object.location.z`
+    or `object.dimensions`, both of which lie after asymmetric mesh edits
+    (e.g., bottom-half deletion of a sphere to make a hemisphere).
+
+    Parameters:
+    - object_name: The object whose base should rest on the ground.
+    - ground_name: The mesh that serves as the ground plane.
+    - slice_height: Meters above the object's bottom to sample from
+      (default 1.0). Keep small for trees / canopy-heavy meshes so the
+      sample is actually the trunk/base, not lower branches.
+    - max_samples: Cap on raycasts (default 500).
+    """
+    try:
+        blender = get_blender_connection()
+        result = blender.send_command("verify_object_grounded", {
+            "object_name": object_name,
+            "ground_name": ground_name,
+            "slice_height": slice_height,
+            "max_samples": max_samples,
+        })
+        return json.dumps(result, indent=2)
+    except Exception as e:
+        logger.error(f"Error verifying grounding: {str(e)}")
+        return f"Error verifying grounding: {str(e)}"
 
 
 @telemetry_tool("execute_blender_code")


### PR DESCRIPTION
## Summary

When the MCP is used by a model (or a person driving it remotely), there is no deterministic way to confirm a visual claim. `object.location.z` and `object.dimensions` lie after asymmetric mesh edits — e.g., a hemisphere built by deleting the bottom of a sphere keeps the original origin, so `location.z - dimensions.z / 2` is 15cm off from the actual base in world space. Displace modifiers on the ground vary z per position, so "put it on z=0" leaves a visible gap or intersection. The result is a feedback loop where the caller reports "fixed" and the user sees the bug.

This PR adds two complementary tools, aimed at the same failure mode from different angles.

### 1. `verify_object_grounded(object_name, ground_name, slice_height=1.0, max_samples=500)`

Samples vertices from the object's lower slice — world z within `slice_height` of its lowest vertex — and raycasts straight down against the ground's evaluated mesh via BVH. Returns min/max/median/mean gap in meters:

```json
{
  "object_name": "Tree.Pine01",
  "ground_name": "Ground",
  "samples_tested": 142,
  "samples_hit": 140,
  "samples_missed": 2,
  "min_gap": -0.042,
  "max_gap": 0.31,
  "median_gap": 0.11,
  "mean_gap": 0.13,
  "slice_height": 1.0,
  "hint": "mixed: tilted or uneven ground; base partly above and partly below"
}
```

Deterministic, no model vision. Evaluated geometry means Displace on the ground and armature / shape-key deformation on the object are honored automatically. `slice_height` is configurable because canopy-dominated meshes (pines, etc.) have most of their verts high up — a bounded z-slice is more reliable than a percentile of sorted verts.

### 2. `get_viewport_screenshot(..., target_object, view, distance_factor, ortho_padding)`

When `target_object` is set, creates a throwaway orthographic camera framed on the target's world bbox, aimed from one of six named axes (`front`, `back`, `left`, `right`, `top`, `bottom`), and renders a clean image. The previous `scene.camera`, render resolution, output path, and image format are saved and restored after the render — the user's setup is untouched. The temp camera and its data block are removed with `do_unlink=True` so no orphans accumulate.

Default path (no `target_object`) is unchanged: the existing viewport screenshot with overlays.

Together these cover both sides of verification:
- `verify_object_grounded` when you want a cheap, deterministic "is it touching?"
- ortho-diag `get_viewport_screenshot` when the question is broader — floating, wrong rotation, wrong color, wrong material.

## Test plan

- [ ] `verify_object_grounded('Cube', 'Plane')` with a default cube on a plane → `min_gap` ≈ 0, `hint` = "grounded or intersecting".
- [ ] Raise the cube 0.5m → `min_gap` ≈ 0.5, `hint` starts with "floating".
- [ ] Sink the cube -0.1m → `min_gap` ≈ -0.1, `hint` = "grounded or intersecting" (all gaps below the 1cm threshold).
- [ ] Tilt the cube so one corner intersects ground → `hint` = "mixed".
- [ ] `verify_object_grounded('Missing', 'Plane')` → error message includes "not found".
- [ ] `verify_object_grounded('Cube', 'EmptyObject')` → error message includes "is not a mesh".
- [ ] `get_viewport_screenshot(target_object='Cube', view='front')` → returns a clean ortho render with the cube centered; user's viewport and scene camera unchanged.
- [ ] Same with `view='top'`, `view='right'`, etc. — renders from the correct axis.
- [ ] Unknown `view` value → error listing valid choices.
- [ ] Default `get_viewport_screenshot()` call (no `target_object`) still returns the viewport-with-overlays screenshot as before.
- [ ] After the diag render, no `_MCPDiagCam` object or camera data block remains in the scene.

## Notes

Downstream tracking bead: `Blender-tqy`. Covers both "shapes" mentioned in the issue description as complementary tools rather than either/or.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added object grounding verification tool that validates spatial relationships and provides gap statistics between objects.
  * Extended viewport screenshot capability to render targeted orthographic diagnostics of specific objects with configurable view angle, distance, and padding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->