### PR TITLE
Add Codex setup docs and generalize MCP client wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # BlenderMCP - Blender Model Context Protocol Integration
 
-BlenderMCP connects Blender to Claude AI through the Model Context Protocol (MCP), allowing Claude to directly interact with and control Blender. This integration enables prompt assisted 3D modeling, scene creation, and manipulation.
+BlenderMCP connects Blender to MCP-compatible clients such as Codex, Claude, Cursor, and VS Code through the Model Context Protocol (MCP). This integration enables prompt-assisted 3D modeling, scene creation, and manipulation.
 
 **We have no official website. Any website you see online is unofficial and has no affiliation with this project. Use them at your own risk.**
 
@@ -32,16 +32,16 @@ Give feedback, get inspired, and build on top of the MCP: [Discord](https://disc
 ### Installating a new version (existing users)
 - For newcomers, you can go straight to Installation. For existing users, see the points below
 - Download the latest addon.py file and replace the older one, then add it to Blender
-- Delete the MCP server from Claude and add it back again, and you should be good to go!
+- Delete the MCP server from your client and add it back again, and you should be good to go!
 
 
 ## Features
 
-- **Two-way communication**: Connect Claude AI to Blender through a socket-based server
+- **Two-way communication**: Connect MCP-compatible clients to Blender through a socket-based server
 - **Object manipulation**: Create, modify, and delete 3D objects in Blender
 - **Material control**: Apply and modify materials and colors
 - **Scene inspection**: Get detailed information about the current Blender scene
-- **Code execution**: Run arbitrary Python code in Blender from Claude
+- **Code execution**: Run arbitrary Python code in Blender from your MCP client
 
 ## Components
 
@@ -67,7 +67,7 @@ brew install uv
 ```powershell
 powershell -c "irm https://astral.sh/uv/install.ps1 | iex" 
 ```
-and then add uv to the user path in Windows (you may need to restart Claude Desktop after):
+and then add uv to the user path in Windows (you may need to restart your MCP client after):
 ```powershell
 $localBin = "$env:USERPROFILE\.local\bin"
 $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
@@ -90,6 +90,20 @@ Example:
 export BLENDER_HOST='host.docker.internal'
 export BLENDER_PORT=9876
 ```
+
+### Codex Integration
+
+Add the following MCP server to your Codex config (`~/.codex/config.toml`):
+
+```toml
+[mcp_servers.blender]
+type = "stdio"
+command = "uvx"
+args = ["blender-mcp"]
+enabled = true
+```
+
+If `uvx` is not yet available on your `PATH` on Windows, point `command` to the full `uvx.exe` path instead.
 
 ### Claude for Desktop Integration
 
@@ -161,7 +175,7 @@ For Windows users, go to Settings > MCP > Add Server, add a new server with the 
 
 [Cursor setup video](https://www.youtube.com/watch?v=wgWsJshecac)
 
-**⚠️ Only run one instance of the MCP server (either on Cursor or Claude Desktop), not both**
+**⚠️ Only run one instance of the MCP server at a time (for example on Codex, Cursor, or Claude Desktop), not multiple clients simultaneously**
 
 ### Visual Studio Code Integration
 
@@ -186,12 +200,12 @@ _Prerequisites_: Make sure you have [Visual Studio Code](https://code.visualstud
 1. In Blender, go to the 3D View sidebar (press N if not visible)
 2. Find the "BlenderMCP" tab
 3. Turn on the Poly Haven checkbox if you want assets from their API (optional)
-4. Click "Connect to Claude"
+4. Click "Connect to MCP server"
 5. Make sure the MCP server is running in your terminal
 
-### Using with Claude
+### Using with MCP Clients
 
-Once the config file has been set on Claude, and the addon is running on Blender, you will see a hammer icon with tools for the Blender MCP.
+Once the config file has been set on your MCP client and the addon is running in Blender, you will see Blender MCP tools in the client.
 
 ![BlenderMCP in the sidebar](assets/hammer-icon.png)
 
@@ -207,7 +221,7 @@ Once the config file has been set on Claude, and the addon is running on Blender
 
 ### Example Commands
 
-Here are some examples of what you can ask Claude to do:
+Here are some examples of what you can ask your MCP client to do:
 
 - "Create a low poly scene in a dungeon, with a dragon guarding a pot of gold" [Demo](https://www.youtube.com/watch?v=DqgKuLYUv00)
 - "Create a beach vibe using HDRIs, textures, and models like rocks and vegetation from Poly Haven" [Demo](https://www.youtube.com/watch?v=I29rn92gkC4)
@@ -225,10 +239,10 @@ Hyper3D's free trial key allows you to generate a limited number of models per d
 
 ## Troubleshooting
 
-- **Connection issues**: Make sure the Blender addon server is running, and the MCP server is configured on Claude, DO NOT run the uvx command in the terminal. Sometimes, the first command won't go through but after that it starts working.
+- **Connection issues**: Make sure the Blender addon server is running, and the MCP server is configured in your client. DO NOT run the `uvx blender-mcp` command manually in the terminal. Sometimes, the first command won't go through but after that it starts working.
 - **Timeout errors**: Try simplifying your requests or breaking them into smaller steps
-- **Poly Haven integration**: Claude is sometimes erratic with its behaviour
-- **Have you tried turning it off and on again?**: If you're still having connection errors, try restarting both Claude and the Blender server
+- **Poly Haven integration**: MCP clients can sometimes be erratic with tool sequencing
+- **Have you tried turning it off and on again?**: If you're still having connection errors, try restarting both your MCP client and the Blender server
 
 
 ## Technical Details

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ _Prerequisites_: Make sure you have [Visual Studio Code](https://code.visualstud
 
 ### Using with MCP Clients
 
-Once the config file has been set on your MCP client and the addon is running in Blender, you will see Blender MCP tools in the client.
+Once the config file has been set in your MCP client and the add-on is running in Blender, you will see Blender MCP tools in the client.
 
 ![BlenderMCP in the sidebar](assets/hammer-icon.png)
 
@@ -239,7 +239,7 @@ Hyper3D's free trial key allows you to generate a limited number of models per d
 
 ## Troubleshooting
 
-- **Connection issues**: Make sure the Blender addon server is running, and the MCP server is configured in your client. DO NOT run the `uvx blender-mcp` command manually in the terminal. Sometimes, the first command won't go through but after that it starts working.
+- **Connection issues**: Make sure the Blender add-on server is running, and the MCP server is configured in your client. DO NOT run the `uvx blender-mcp` command manually in the terminal. Sometimes, the first command won't go through but after that it starts working.
 - **Timeout errors**: Try simplifying your requests or breaking them into smaller steps
 - **Poly Haven integration**: MCP clients can sometimes be erratic with tool sequencing
 - **Have you tried turning it off and on again?**: If you're still having connection errors, try restarting both your MCP client and the Blender server

--- a/addon.py
+++ b/addon.py
@@ -26,7 +26,7 @@ bl_info = {
     "version": (1, 2),
     "blender": (3, 0, 0),
     "location": "View3D > Sidebar > BlenderMCP",
-    "description": "Connect Blender to Claude via MCP",
+    "description": "Connect Blender to MCP-compatible clients via MCP",
     "category": "Interface",
 }
 
@@ -1135,7 +1135,7 @@ class BlenderMCPServer:
                 "message": """PolyHaven integration is currently disabled. To enable it:
                             1. In the 3D Viewport, find the BlenderMCP panel in the sidebar (press N if hidden)
                             2. Check the 'Use assets from Poly Haven' checkbox
-                            3. Restart the connection to Claude"""
+                            3. Restart the MCP client connection"""
         }
 
     #region Hyper3D
@@ -1150,7 +1150,7 @@ class BlenderMCPServer:
                                 1. In the 3D Viewport, find the BlenderMCP panel in the sidebar (press N if hidden)
                                 2. Keep the 'Use Hyper3D Rodin 3D model generation' checkbox checked
                                 3. Choose the right plaform and fill in the API Key
-                                4. Restart the connection to Claude"""
+                                4. Restart the MCP client connection"""
                 }
             mode = bpy.context.scene.blendermcp_hyper3d_mode
             message = f"Hyper3D Rodin integration is enabled and ready to use. Mode: {mode}. " + \
@@ -1165,7 +1165,7 @@ class BlenderMCPServer:
                 "message": """Hyper3D Rodin integration is currently disabled. To enable it:
                             1. In the 3D Viewport, find the BlenderMCP panel in the sidebar (press N if hidden)
                             2. Check the 'Use Hyper3D Rodin 3D model generation' checkbox
-                            3. Restart the connection to Claude"""
+                            3. Restart the MCP client connection"""
             }
 
     def create_rodin_job(self, *args, **kwargs):
@@ -1525,7 +1525,7 @@ class BlenderMCPServer:
                             1. In the 3D Viewport, find the BlenderMCP panel in the sidebar (press N if hidden)
                             2. Keep the 'Use Sketchfab' checkbox checked
                             3. Enter your Sketchfab API Key
-                            4. Restart the connection to Claude"""
+                            4. Restart the MCP client connection"""
             }
         else:
             return {
@@ -1534,7 +1534,7 @@ class BlenderMCPServer:
                             1. In the 3D Viewport, find the BlenderMCP panel in the sidebar (press N if hidden)
                             2. Check the 'Use assets from Sketchfab' checkbox
                             3. Enter your Sketchfab API Key
-                            4. Restart the connection to Claude"""
+                            4. Restart the MCP client connection"""
             }
 
     def search_sketchfab_models(self, query, categories=None, count=20, downloadable=True):
@@ -1925,7 +1925,7 @@ class BlenderMCPServer:
                                 1. In the 3D Viewport, find the BlenderMCP panel in the sidebar (press N if hidden)
                                 2. Keep the 'Use Tencent Hunyuan 3D model generation' checkbox checked
                                 3. Choose the right platform and fill in the SecretId and SecretKey
-                                4. Restart the connection to Claude"""
+                                4. Restart the MCP client connection"""
                         }
                 case "LOCAL_API":
                     if not bpy.context.scene.blendermcp_hunyuan3d_api_url:
@@ -1936,7 +1936,7 @@ class BlenderMCPServer:
                                 1. In the 3D Viewport, find the BlenderMCP panel in the sidebar (press N if hidden)
                                 2. Keep the 'Use Tencent Hunyuan 3D model generation' checkbox checked
                                 3. Choose the right platform and fill in the API URL
-                                4. Restart the connection to Claude"""
+                                4. Restart the MCP client connection"""
                         }
                 case _:
                     return {
@@ -1953,7 +1953,7 @@ class BlenderMCPServer:
             "message": """Hunyuan3D integration is currently disabled. To enable it:
                         1. In the 3D Viewport, find the BlenderMCP panel in the sidebar (press N if hidden)
                         2. Check the 'Use Tencent Hunyuan 3D model generation' checkbox
-                        3. Restart the connection to Claude"""
+                        3. Restart the MCP client connection"""
         }
     
     @staticmethod
@@ -2413,8 +2413,8 @@ class BLENDERMCP_OT_SetFreeTrialHyper3DAPIKey(bpy.types.Operator):
 # Operator to start the server
 class BLENDERMCP_OT_StartServer(bpy.types.Operator):
     bl_idname = "blendermcp.start_server"
-    bl_label = "Connect to Claude"
-    bl_description = "Start the BlenderMCP server to connect with Claude"
+    bl_label = "Connect to MCP client"
+    bl_description = "Start the BlenderMCP server for your MCP client"
 
     def execute(self, context):
         scene = context.scene
@@ -2432,8 +2432,8 @@ class BLENDERMCP_OT_StartServer(bpy.types.Operator):
 # Operator to stop the server
 class BLENDERMCP_OT_StopServer(bpy.types.Operator):
     bl_idname = "blendermcp.stop_server"
-    bl_label = "Stop the connection to Claude"
-    bl_description = "Stop the connection to Claude"
+    bl_label = "Disconnect from MCP client"
+    bl_description = "Stop the BlenderMCP server for your MCP client"
 
     def execute(self, context):
         scene = context.scene

--- a/addon.py
+++ b/addon.py
@@ -2394,9 +2394,9 @@ class BLENDERMCP_PT_Panel(bpy.types.Panel):
                 layout.prop(scene, "blendermcp_hunyuan3d_texture", text="Generate Texture")
         
         if not scene.blendermcp_server_running:
-            layout.operator("blendermcp.start_server", text="Connect to MCP server")
+            layout.operator("blendermcp.start_server")
         else:
-            layout.operator("blendermcp.stop_server", text="Disconnect from MCP server")
+            layout.operator("blendermcp.stop_server")
             layout.label(text=f"Running on port {scene.blendermcp_port}")
 
 # Operator to set Hyper3D API Key


### PR DESCRIPTION
## Summary
- add Codex setup instructions for BlenderMCP in ~/.codex/config.toml
- generalize Claude-specific README wording to cover MCP-compatible clients
- update add-on labels and guidance strings to refer to MCP clients instead of Claude

## Validation
- verified the Blender add-on still loads successfully
- tested Codex against BlenderMCP locally and confirmed scene operations work
- tested GitHub Copilot against BlenderMCP locally and confirmed scene operations work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated docs and UI messaging to refer to MCP-compatible clients instead of a single client
  * Added Codex integration guidance with example configuration and Windows notes
  * Revised troubleshooting and restart instructions for MCP client workflows

* **Documentation**
  * Updated on-screen labels and button text to reference connecting/disconnecting to an MCP client rather than the previous client name
<!-- end of auto-generated comment: release notes by coderabbit.ai -->