### PR TITLE
fix: validate Hyper3D image URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Give feedback, get inspired, and build on top of the MCP: [Discord](https://disc
 - Run Blender MCP on a remote host
 - Telemetry for tools executed (completely anonymous)
 
-### Installating a new version (existing users)
+### Installing a new version (existing users)
 - For newcomers, you can go straight to Installation. For existing users, see the points below
 - Download the latest addon.py file and replace the older one, then add it to Blender
 - Delete the MCP server from Claude and add it back again, and you should be good to go!
@@ -227,7 +227,7 @@ Hyper3D's free trial key allows you to generate a limited number of models per d
 
 - **Connection issues**: Make sure the Blender addon server is running, and the MCP server is configured on Claude, DO NOT run the uvx command in the terminal. Sometimes, the first command won't go through but after that it starts working.
 - **Timeout errors**: Try simplifying your requests or breaking them into smaller steps
-- **Poly Haven integration**: Claude is sometimes erratic with its behaviour
+- **Poly Haven integration**: Claude is sometimes erratic with its behavior
 - **Have you tried turning it off and on again?**: If you're still having connection errors, try restarting both Claude and the Blender server
 
 

--- a/addon.py
+++ b/addon.py
@@ -2488,7 +2488,7 @@ def register():
 
     bpy.types.Scene.blendermcp_use_hyper3d = bpy.props.BoolProperty(
         name="Use Hyper3D Rodin",
-        description="Enable Hyper3D Rodin generatino integration",
+        description="Enable Hyper3D Rodin generation integration",
         default=False
     )
 

--- a/src/blender_mcp/server.py
+++ b/src/blender_mcp/server.py
@@ -802,6 +802,12 @@ def _process_bbox(original_bbox: list[float] | list[int] | None) -> list[int] | 
         raise ValueError("Incorrect number range: bbox must be bigger than zero!")
     return [int(float(i) / max(original_bbox) * 100) for i in original_bbox] if original_bbox else None
 
+def _is_valid_image_url(url: str) -> bool:
+    if not isinstance(url, str) or not url:
+        return False
+    parsed = urlparse(url)
+    return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
+
 @telemetry_tool("generate_hyper3d_model_via_text")
 @mcp.tool()
 def generate_hyper3d_model_via_text(
@@ -874,7 +880,7 @@ def generate_hyper3d_model_via_images(
                     (Path(path).suffix, base64.b64encode(f.read()).decode("ascii"))
                 )
     elif input_image_urls is not None:
-        if not all(urlparse(i) for i in input_image_paths):
+        if not all(_is_valid_image_url(i) for i in input_image_urls):
             return "Error: not all image URLs are valid!"
         images = input_image_urls.copy()
     try:


### PR DESCRIPTION
## Summary
- Validate `input_image_urls` in the Hyper3D image URL branch instead of `input_image_paths`
- Fix a few small typos in README and add-on text

## Testing
- `uv run python -m compileall src addon.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed URL validation for image-based Hyper3D model generation to ensure only valid http/https image links are accepted.
  * Corrected a typo in a UI option so the property description now reads correctly for Hyper3D generation.

* **Documentation**
  * Fixed typos and wording in the README, improving installation and troubleshooting clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->