### PR TITLE
fix: keep server state out of bpy.types

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -2621,6 +2621,27 @@ class BLENDERMCP_OT_SetFreeTrialHyper3DAPIKey(bpy.types.Operator):
         self.report({'INFO'}, "API Key set successfully!")
         return {'FINISHED'}
 
+
+_server_instance = None
+
+
+def _ensure_server(port):
+    global _server_instance
+
+    if _server_instance is None:
+        _server_instance = BlenderMCPServer(port=port)
+
+    return _server_instance
+
+
+def _stop_server():
+    global _server_instance
+
+    if _server_instance is not None:
+        _server_instance.stop()
+        _server_instance = None
+
+
 # Operator to start the server
 class BLENDERMCP_OT_StartServer(bpy.types.Operator):
     bl_idname = "blendermcp.start_server"
@@ -2630,13 +2651,9 @@ class BLENDERMCP_OT_StartServer(bpy.types.Operator):
     def execute(self, context):
         scene = context.scene
 
-        # Create a new server instance
-        if not hasattr(bpy.types, "blendermcp_server") or not bpy.types.blendermcp_server:
-            bpy.types.blendermcp_server = BlenderMCPServer(port=scene.blendermcp_port)
-
-        # Start the server
-        bpy.types.blendermcp_server.start()
-        scene.blendermcp_server_running = bpy.types.blendermcp_server.running
+        server = _ensure_server(scene.blendermcp_port)
+        server.start()
+        scene.blendermcp_server_running = server.running
 
         return {'FINISHED'}
 
@@ -2649,11 +2666,7 @@ class BLENDERMCP_OT_StopServer(bpy.types.Operator):
     def execute(self, context):
         scene = context.scene
 
-        # Stop the server if it exists
-        if hasattr(bpy.types, "blendermcp_server") and bpy.types.blendermcp_server:
-            bpy.types.blendermcp_server.stop()
-            del bpy.types.blendermcp_server
-
+        _stop_server()
         scene.blendermcp_server_running = False
 
         return {'FINISHED'}
@@ -2822,22 +2835,18 @@ def register():
         port = 9876
         auto_start = True
 
-    if auto_start and (not hasattr(bpy.types, "blendermcp_server") or not bpy.types.blendermcp_server):
-        bpy.types.blendermcp_server = BlenderMCPServer(port=port)
-    if auto_start and not bpy.types.blendermcp_server.running:
-        bpy.types.blendermcp_server.start()
+    server = _ensure_server(port) if auto_start else None
+    if server is not None and not server.running:
+        server.start()
         try:
-            bpy.context.scene.blendermcp_server_running = bpy.types.blendermcp_server.running
+            bpy.context.scene.blendermcp_server_running = server.running
         except AttributeError:
             pass
 
     print("BlenderMCP addon registered")
 
 def unregister():
-    # Stop the server if it's running
-    if hasattr(bpy.types, "blendermcp_server") and bpy.types.blendermcp_server:
-        bpy.types.blendermcp_server.stop()
-        del bpy.types.blendermcp_server
+    _stop_server()
 
     bpy.utils.unregister_class(BLENDERMCP_PT_Panel)
     bpy.utils.unregister_class(BLENDERMCP_OT_SetFreeTrialHyper3DAPIKey)

--- a/test_server_state_storage.py
+++ b/test_server_state_storage.py
@@ -1,0 +1,67 @@
+"""Regression checks for BlenderMCP server instance storage.
+
+Runtime instances must not be attached to ``bpy.types`` because Blender treats
+that namespace as a class registry and calls ``issubclass`` on its entries when
+saving theme presets.
+"""
+
+import ast
+import pathlib
+
+
+ADDON = pathlib.Path(__file__).with_name("addon.py")
+
+
+def _source():
+    return ADDON.read_text()
+
+
+def _load_server_state_helpers():
+    tree = ast.parse(_source())
+    selected_nodes = []
+
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            if any(isinstance(target, ast.Name) and target.id == "_server_instance" for target in node.targets):
+                selected_nodes.append(node)
+        elif isinstance(node, ast.FunctionDef) and node.name in {"_ensure_server", "_stop_server"}:
+            selected_nodes.append(node)
+
+    module = ast.Module(body=selected_nodes, type_ignores=[])
+    ast.fix_missing_locations(module)
+
+    class FakeServer:
+        def __init__(self, port):
+            self.port = port
+            self.running = False
+            self.stop_calls = 0
+
+        def stop(self):
+            self.stop_calls += 1
+            self.running = False
+
+    namespace = {"BlenderMCPServer": FakeServer}
+    exec(compile(module, str(ADDON), "exec"), namespace)
+    return namespace
+
+
+def test_server_instance_is_not_stored_on_bpy_types():
+    assert "bpy.types.blendermcp_server" not in _source()
+
+
+def test_server_helpers_reuse_and_release_module_state():
+    namespace = _load_server_state_helpers()
+
+    first = namespace["_ensure_server"](9876)
+    second = namespace["_ensure_server"](9001)
+
+    assert second is first
+    assert first.port == 9876
+
+    namespace["_stop_server"]()
+    assert first.stop_calls == 1
+    assert namespace["_server_instance"] is None
+
+    replacement = namespace["_ensure_server"](9001)
+    assert replacement is not first
+    assert replacement.port == 9001


### PR DESCRIPTION
## Summary

- keep the BlenderMCP server instance in module state instead of attaching it to `bpy.types`
- reuse the same lifecycle helpers for manual start, stop, auto-start, and addon unregister
- add a Blender-independent regression test for instance reuse and cleanup

Blender treats `bpy.types` as a class registry. Storing a `BlenderMCPServer` instance there causes theme preset serialization to call `issubclass()` on a non-class and abort.

## Testing

- `uv run --with pytest pytest -q`
- `python -m py_compile addon.py test_server_state_storage.py`
- `git diff --check`

Closes #245