### PR TITLE
Change telemetry consent to opt-in instead of opt-out

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -2478,7 +2478,7 @@ class BLENDERMCP_AddonPreferences(bpy.types.AddonPreferences):
     telemetry_consent: BoolProperty(
         name="Allow Telemetry",
         description="Allow collection of prompts, code snippets, and screenshots to help improve Blender MCP",
-        default=True
+        default=False
     )
     hyper3d_api_key: bpy.props.StringProperty(
         name="Hyper3D API Key",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Changes

This PR changes the telemetry consent checkbox in the addon preferences from opt-out to opt-in by modifying the default value of the `telemetry_consent` BoolProperty.

## Details

- Changed `default=True` to `default=False` in the `telemetry_consent` BoolProperty definition
- Users will now need to explicitly enable telemetry by checking the checkbox in preferences
- Previously, users had to uncheck the box to disable telemetry (opt-out)

## Impact

This change makes telemetry collection more privacy-friendly by requiring explicit user consent before collecting prompts, code snippets, and screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sids-agents.slack.com/archives/C0BHZ444DM5/p1784638678504529?thread_ts=1784638678.504529&cid=C0BHZ444DM5)

<div><a href="https://cursor.com/agents/bc-f4cd990f-b3eb-5c9d-ab6d-f09bfaae9166"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f4cd990f-b3eb-5c9d-ab6d-f09bfaae9166"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

