### PR TITLE
Add feedback links to addon.py and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,12 @@ Or add it to your MCP config:
 
 All telemetry data is fully anonymized and used solely to improve BlenderMCP.
 
+## Feedback
+
+We are actively looking for feedback on Blender MCP. If you have thoughts, share them [here](https://forms.gle/PDr2DXxAnSH3d9uZ9).
+
+If you have more detailed feedback, you can schedule a call with us [here](https://bit.ly/blender-mcp-feedback) - we will credit you in the project.
+
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -363,9 +363,9 @@ All telemetry data is fully anonymized and used solely to improve BlenderMCP.
 
 ## Feedback
 
-We are actively looking for feedback on Blender MCP. If you have thoughts, share them [here](https://forms.gle/PDr2DXxAnSH3d9uZ9).
+We are actively looking for feedback on Blender MCP. If you have thoughts, share them [here](https://bit.ly/blender-mcp-form).
 
-If you have more detailed feedback, you can schedule a call with us [here](https://bit.ly/blender-mcp-feedback) - we will credit you in the project.
+If you have more detailed feedback, you can schedule a call with us [here](https://bit.ly/blender-mcp-call) - we will credit you in the project.
 
 
 ## Contributing

--- a/addon.py
+++ b/addon.py
@@ -2604,7 +2604,7 @@ class BLENDERMCP_PT_Panel(bpy.types.Panel):
         # Feedback section
         layout.separator()
         feedback_box = layout.box()
-        feedback_box.scale_y = 0.4
+        
         col = feedback_box.column(align=True)
         col.label(text="Feedback", icon='URL')
         col.label(text="forms.gle/PDr2DXxAnSH3d9uZ9")

--- a/addon.py
+++ b/addon.py
@@ -2607,10 +2607,10 @@ class BLENDERMCP_PT_Panel(bpy.types.Panel):
         
         col = feedback_box.column(align=True)
         col.label(text="Feedback", icon='URL')
-        col.label(text="forms.gle/PDr2DXxAnSH3d9uZ9")
+        col.label(text="bit.ly/blender-mcp-form")
         col.separator()
         col.label(text="Schedule a call", icon='URL')
-        col.label(text="bit.ly/blender-mcp-feedback")
+        col.label(text="bit.ly/blender-mcp-call")
         col.label(text="(we'll credit you in the repo!)")
 
 # Operator to set Hyper3D API Key

--- a/addon.py
+++ b/addon.py
@@ -2600,6 +2600,20 @@ class BLENDERMCP_PT_Panel(bpy.types.Panel):
         else:
             layout.operator("blendermcp.stop_server", text="Disconnect from MCP server")
             layout.label(text=f"Running on port {scene.blendermcp_port}")
+        
+        # Feedback section
+        layout.separator()
+        feedback_box = layout.box()
+        feedback_box.scale_y = 0.6
+        col = feedback_box.column(align=True)
+        col.scale_y = 0.8
+        col.label(text="We are actively looking for feedback on Blender MCP.")
+        col.label(text="If you have thoughts, share them at:")
+        col.label(text="https://forms.gle/PDr2DXxAnSH3d9uZ9")
+        col.separator(factor=0.5)
+        col.label(text="For detailed feedback, schedule a call:")
+        col.label(text="https://bit.ly/blender-mcp-feedback")
+        col.label(text="- we will credit you in the project")
 
 # Operator to set Hyper3D API Key
 class BLENDERMCP_OT_SetFreeTrialHyper3DAPIKey(bpy.types.Operator):

--- a/addon.py
+++ b/addon.py
@@ -2606,11 +2606,12 @@ class BLENDERMCP_PT_Panel(bpy.types.Panel):
         feedback_box = layout.box()
         feedback_box.scale_y = 0.4
         col = feedback_box.column(align=True)
-        col.scale_y = 0.6
-        col.label(text="Feedback: forms.gle/PDr2DXxAnSH3d9uZ9")
-        col.separator(factor=0.3)
-        col.label(text="Call: bit.ly/blender-mcp-feedback")
-        col.label(text="(we'll credit you!)")
+        col.label(text="Feedback", icon='URL')
+        col.label(text="forms.gle/PDr2DXxAnSH3d9uZ9")
+        col.separator()
+        col.label(text="Schedule a call", icon='URL')
+        col.label(text="bit.ly/blender-mcp-feedback")
+        col.label(text="(we'll credit you in the repo!)")
 
 # Operator to set Hyper3D API Key
 class BLENDERMCP_OT_SetFreeTrialHyper3DAPIKey(bpy.types.Operator):

--- a/addon.py
+++ b/addon.py
@@ -2604,16 +2604,13 @@ class BLENDERMCP_PT_Panel(bpy.types.Panel):
         # Feedback section
         layout.separator()
         feedback_box = layout.box()
-        feedback_box.scale_y = 0.6
+        feedback_box.scale_y = 0.4
         col = feedback_box.column(align=True)
-        col.scale_y = 0.8
-        col.label(text="We are actively looking for feedback on Blender MCP.")
-        col.label(text="If you have thoughts, share them at:")
-        col.label(text="https://forms.gle/PDr2DXxAnSH3d9uZ9")
-        col.separator(factor=0.5)
-        col.label(text="For detailed feedback, schedule a call:")
-        col.label(text="https://bit.ly/blender-mcp-feedback")
-        col.label(text="- we will credit you in the project")
+        col.scale_y = 0.6
+        col.label(text="Feedback: forms.gle/PDr2DXxAnSH3d9uZ9")
+        col.separator(factor=0.3)
+        col.label(text="Call: bit.ly/blender-mcp-feedback")
+        col.label(text="(we'll credit you!)")
 
 # Operator to set Hyper3D API Key
 class BLENDERMCP_OT_SetFreeTrialHyper3DAPIKey(bpy.types.Operator):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
This PR adds feedback links to both the Blender addon UI and the README to encourage users to share their thoughts and schedule calls for detailed feedback.

## Changes
- **addon.py**: Added a clean feedback section at the bottom of the BlenderMCP panel (below the connect/disconnect button) with:
  - "Feedback" label with URL icon → bit.ly/blender-mcp-form
  - "Schedule a call" label with URL icon → bit.ly/blender-mcp-call
  - Credit message: "(we'll credit you in the repo!)"
  - Natural spacing with proper separators

- **README.md**: Added a new "Feedback" section with hyperlinked text:
  - "If you have thoughts, share them [here]" (linking to bit.ly/blender-mcp-form)
  - "If you have more detailed feedback, you can schedule a call with us [here]" (linking to bit.ly/blender-mcp-call)
  - Includes note about crediting contributors

## Visual Impact
The feedback section in the addon UI has a clean layout with URL icons, well-spaced text, and concise bit.ly URLs that are easy to read and type.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sids-agents.slack.com/archives/C0BHZ444DM5/p1784640501411639?thread_ts=1784640501.411639&cid=C0BHZ444DM5)

<div><a href="https://cursor.com/agents/bc-24528f3a-b24a-5677-8f56-f93b16dece3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-24528f3a-b24a-5677-8f56-f93b16dece3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

