### PR TITLE
fix: add length-prefixed framing to prevent incomplete JSON responses (#219, #279, #256)

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -6,6 +6,7 @@ import mathutils
 import json
 import threading
 import socket
+import struct
 import time
 import requests
 import tempfile
@@ -35,6 +36,13 @@ RODIN_FREE_TRIAL_KEY = "vibecoding"
 # Add User-Agent as required by Poly Haven API
 REQ_HEADERS = requests.utils.default_headers()
 REQ_HEADERS.update({"User-Agent": "blender-mcp"})
+
+
+def _send_framed_json(client, payload):
+    """Send one JSON object with a 4-byte big-endian length prefix."""
+    body = json.dumps(payload).encode("utf-8")
+    client.sendall(struct.pack(">I", len(body)) + body)
+
 
 def get_blendermcp_addon_preferences(context=None):
     """Get add-on preferences object if available."""
@@ -218,10 +226,9 @@ class BlenderMCPServer:
                         def execute_wrapper():
                             try:
                                 response = self.execute_command(command)
-                                response_json = json.dumps(response)
                                 try:
-                                    client.sendall(response_json.encode('utf-8'))
-                                except:
+                                    _send_framed_json(client, response)
+                                except Exception:
                                     print("Failed to send response - client disconnected")
                             except Exception as e:
                                 print(f"Error executing command: {str(e)}")
@@ -231,8 +238,8 @@ class BlenderMCPServer:
                                         "status": "error",
                                         "message": str(e)
                                     }
-                                    client.sendall(json.dumps(error_response).encode('utf-8'))
-                                except:
+                                    _send_framed_json(client, error_response)
+                                except Exception:
                                     pass
                             return None
 

--- a/scripts/benchmark_mcp_socket.py
+++ b/scripts/benchmark_mcp_socket.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""
+Stress-test Blender MCP socket (Issue #279 repro helper).
+
+Requires Blender GUI + community addon listening on BLENDER_HOST:9876.
+
+Usage:
+  BLENDER_HOST=172.19.96.1 uv run --directory . python scripts/benchmark_mcp_socket.py --iterations 20
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import socket
+import statistics
+import time
+
+from blender_mcp.socket_framing import pack_json_message, receive_framed_bytes
+
+DEFAULT_HOST = os.getenv("BLENDER_HOST", "localhost")
+DEFAULT_PORT = int(os.getenv("BLENDER_PORT", "9876"))
+
+
+def run_command(host: str, port: int, command_type: str, timeout: float) -> tuple[float, int]:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(timeout)
+    start = time.perf_counter()
+    try:
+        sock.connect((host, port))
+        command = {"type": command_type, "params": {}}
+        sock.sendall(pack_json_message(command))
+        data = receive_framed_bytes(sock, timeout=timeout)
+        elapsed = time.perf_counter() - start
+        return elapsed, len(data)
+    finally:
+        sock.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Benchmark MCP socket commands")
+    parser.add_argument("--host", default=DEFAULT_HOST)
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT)
+    parser.add_argument("--iterations", type=int, default=20)
+    parser.add_argument("--command", default="get_scene_info")
+    parser.add_argument("--timeout", type=float, default=180.0)
+    args = parser.parse_args()
+
+    timings: list[float] = []
+    sizes: list[int] = []
+
+    print(f"Target {args.host}:{args.port} command={args.command} n={args.iterations}")
+    for i in range(args.iterations):
+        try:
+            elapsed, size = run_command(args.host, args.port, args.command, args.timeout)
+            timings.append(elapsed)
+            sizes.append(size)
+            print(f"  {i + 1:3d}: {elapsed:6.2f}s  {size:6d} bytes")
+        except Exception as exc:
+            print(f"  {i + 1:3d}: FAIL {exc}")
+            break
+
+    if timings:
+        print(
+            f"Summary: n={len(timings)} "
+            f"min={min(timings):.2f}s p50={statistics.median(timings):.2f}s "
+            f"max={max(timings):.2f}s avg={statistics.mean(timings):.2f}s"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_cadiz_dogfooding_workflow.py
+++ b/scripts/run_cadiz_dogfooding_workflow.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""
+Cádiz Asset Pack v0.1 — full workflow via Blender MCP socket (same transport as MCP tools).
+
+Requires Blender 5.1 GUI + addon MCP server on BLENDER_HOST:9876.
+
+Usage:
+  BLENDER_HOST=172.19.96.1 uv run --directory . python scripts/run_cadiz_dogfooding_workflow.py \\
+    --geojson /mnt/c/Users/druiz/blender-data/gta-andalucia/cadiz-centro/cadiz-centro_buildings.geojson \\
+    --benchmark-out /path/to/BENCHMARK-CADIZ-MCP-ISSUE-219-appendix.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+# Repo src on path
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from blender_mcp.server import BlenderConnection  # noqa: E402
+
+GEOJSON_DEFAULT = (
+    "/mnt/c/Users/druiz/blender-data/gta-andalucia/cadiz-centro/cadiz-centro_buildings.geojson"
+)
+GLB_DEFAULT = "/mnt/c/Users/druiz/blender-exports/cadiz_buildings_full.glb"
+SCREENSHOT_DIR = "/mnt/c/Users/druiz/blender-data/gta-andalucia/screenshots"
+
+
+class BenchLog:
+    def __init__(self) -> None:
+        self.lines: list[str] = []
+
+    def record(self, command: str, elapsed: float, status: str, detail: str = "") -> None:
+        line = f"Comando: {command}\nTiempo: {elapsed:.2f}s\nStatus: {status}"
+        if detail:
+            line += f"\nNotas: {detail}"
+        self.lines.append(line)
+        print(line.replace("\n", " | "))
+
+    def write(self, path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        body = "\n\n---\n\n".join(self.lines)
+        path.write_text(
+            f"# Cádiz MCP workflow benchmark (auto)\n\n"
+            f"Generado: {time.strftime('%Y-%m-%d %H:%M:%S %Z')}\n\n---\n\n{body}\n",
+            encoding="utf-8",
+        )
+
+
+def run_code(conn: BlenderConnection, code: str, bench: BenchLog, label: str) -> dict:
+    t0 = time.perf_counter()
+    try:
+        result = conn.send_command("execute_code", {"code": code})
+        bench.record(label, time.perf_counter() - t0, "OK")
+        return result
+    except Exception as exc:
+        bench.record(label, time.perf_counter() - t0, "FAIL", str(exc))
+        raise
+
+
+def phase_cleanup(conn: BlenderConnection, bench: BenchLog) -> None:
+    code = """
+import bpy
+removed = []
+for name in ("Cube", "Light", "Camera"):
+    obj = bpy.data.objects.get(name)
+    if obj:
+        bpy.data.objects.remove(obj, do_unlink=True)
+        removed.append(name)
+print("removed", removed)
+"""
+    run_code(conn, code, bench, "execute_code (scene cleanup)")
+
+
+def phase_import(conn: BlenderConnection, bench: BenchLog, geojson_path: str) -> None:
+    # Windows path for Blender on Windows; fallback WSL mount
+    win_path = geojson_path.replace("/mnt/c/", "C:\\\\").replace("/", "\\\\")
+    code = f'''
+import bpy
+import json
+import bmesh
+from mathutils import Vector
+
+path_wsl = r"{geojson_path}"
+path_win = r"{win_path}"
+for p in (path_win, path_wsl):
+    try:
+        with open(p, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        path_used = p
+        break
+    except OSError:
+        data = None
+if not data:
+    raise FileNotFoundError("GeoJSON not found: " + path_wsl)
+
+coll_name = "cadiz-centro_buildings"
+if coll_name in bpy.data.collections:
+    old = bpy.data.collections[coll_name]
+    for obj in list(old.objects):
+        bpy.data.objects.remove(obj, do_unlink=True)
+    bpy.data.collections.remove(old)
+
+coll = bpy.data.collections.new(coll_name)
+bpy.context.scene.collection.children.link(coll)
+
+count = 0
+for feat in data.get("features", []):
+    geom = feat.get("geometry") or {{}}
+    if geom.get("type") != "Polygon":
+        continue
+    rings = geom.get("coordinates") or []
+    if not rings:
+        continue
+    coords = rings[0]
+    mesh = bpy.data.meshes.new(f"Building_{{count:04d}}")
+    bm = bmesh.new()
+    verts = [bm.verts.new((c[0], c[1], 0.0)) for c in coords]
+    bm.verts.ensure_lookup_table()
+    try:
+        bm.faces.new(verts)
+    except ValueError:
+        bm.free()
+        continue
+    bm.to_mesh(mesh)
+    bm.free()
+    obj = bpy.data.objects.new(mesh.name, mesh)
+    coll.objects.link(obj)
+    props = feat.get("properties") or {{}}
+    for k, v in props.items():
+        try:
+            obj[k] = v
+        except TypeError:
+            pass
+    count += 1
+
+print("imported", count, "from", path_used)
+'''
+    run_code(conn, code, bench, "execute_code (import GeoJSON)")
+
+
+def phase_heights(conn: BlenderConnection, bench: BenchLog) -> None:
+    code = '''
+import bpy
+
+def get_building_height(obj):
+    height_tag = obj.get("height")
+    if height_tag:
+        try:
+            return max(float(str(height_tag).split()[0].replace("m","")), 3.0)
+        except ValueError:
+            pass
+    levels_tag = obj.get("building:levels")
+    if levels_tag:
+        try:
+            return float(levels_tag) * 3.0
+        except ValueError:
+            pass
+    building_type = obj.get("building", "yes")
+    heights = {
+        "cathedral": 25.0, "church": 18.0, "house": 9.0,
+        "apartments": 15.0, "commercial": 12.0, "yes": 9.0,
+    }
+    return heights.get(building_type, 9.0)
+
+collection = bpy.data.collections.get("cadiz-centro_buildings")
+if not collection:
+    collection = bpy.data.collections.get("GeoJSON_Import")
+if not collection:
+    print("no collection")
+else:
+    n = 0
+    for obj in collection.objects:
+        if obj.type != "MESH":
+            continue
+        height = get_building_height(obj)
+        mod = obj.modifiers.new("Building_Height", "SOLIDIFY")
+        mod.thickness = height
+        mod.offset = 1.0
+        n += 1
+    print("solidify", n)
+'''
+    run_code(conn, code, bench, "execute_code (Solidify 2355)")
+
+
+def phase_materials(conn: BlenderConnection, bench: BenchLog) -> None:
+    code = '''
+import bpy
+mat = bpy.data.materials.get("Building_Material_Basic")
+if not mat:
+    mat = bpy.data.materials.new("Building_Material_Basic")
+    mat.use_nodes = True
+    nodes = mat.node_tree.nodes
+    nodes.clear()
+    bsdf = nodes.new("ShaderNodeBsdfPrincipled")
+    bsdf.inputs["Base Color"].default_value = (0.9, 0.85, 0.8, 1.0)
+    bsdf.inputs["Roughness"].default_value = 0.7
+    out = nodes.new("ShaderNodeOutputMaterial")
+    mat.node_tree.links.new(bsdf.outputs["BSDF"], out.inputs["Surface"])
+
+collection = bpy.data.collections.get("cadiz-centro_buildings") or bpy.data.collections.get("GeoJSON_Import")
+count = 0
+if collection:
+    for obj in collection.objects:
+        if obj.type != "MESH":
+            continue
+        if not obj.data.materials:
+            obj.data.materials.append(mat)
+        else:
+            obj.data.materials[0] = mat
+        count += 1
+print("materials", count)
+'''
+    run_code(conn, code, bench, "execute_code (materials)")
+
+
+def phase_fix_z(conn: BlenderConnection, bench: BenchLog) -> None:
+    code = '''
+import bpy
+from mathutils import Matrix
+
+collection = bpy.data.collections.get("cadiz-centro_buildings") or bpy.data.collections.get("GeoJSON_Import")
+if not collection:
+    print("no collection")
+else:
+    z_min = float("inf")
+    for obj in collection.objects:
+        if obj.type != "MESH":
+            continue
+        for v in obj.data.vertices:
+            world_co = obj.matrix_world @ v.co
+            z_min = min(z_min, world_co.z)
+    print("z_min_before", round(z_min, 2))
+    if z_min < 0:
+        offset = abs(z_min) + 0.5
+        translation = Matrix.Translation((0, 0, offset))
+        for obj in collection.objects:
+            if obj.type == "MESH":
+                obj.data.transform(translation)
+        print("offset_applied", round(offset, 2))
+    else:
+        print("no_fix_needed")
+'''
+    run_code(conn, code, bench, "execute_code (fix elevation Z)")
+
+
+def phase_export_glb(conn: BlenderConnection, bench: BenchLog, glb_path: str) -> None:
+    win_path = glb_path.replace("/mnt/c/", "C:\\\\").replace("/", "\\\\")
+    code = f'''
+import bpy
+import os
+
+collection = bpy.data.collections.get("cadiz-centro_buildings") or bpy.data.collections.get("GeoJSON_Import")
+bpy.ops.object.select_all(action="DESELECT")
+if collection:
+    for obj in collection.objects:
+        obj.select_set(True)
+out_paths = [r"{win_path}", r"{glb_path}"]
+for output_path in out_paths:
+    try:
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        bpy.ops.export_scene.gltf(
+            filepath=output_path,
+            use_selection=True,
+            export_format="GLB",
+            export_materials="EXPORT",
+            export_colors=True,
+        )
+        size = os.path.getsize(output_path)
+        print("glb", output_path, size)
+        break
+    except OSError as e:
+        last = e
+else:
+    raise last
+'''
+    run_code(conn, code, bench, "execute_code (export GLB)")
+
+
+def phase_screenshot(conn: BlenderConnection, bench: BenchLog, out_dir: str) -> None:
+    t0 = time.perf_counter()
+    try:
+        win_dir = out_dir.replace("/mnt/c/", "C:/").replace("/", "/")
+        path = f"{win_dir}/cadiz-mcp-perspective.png"
+        conn.send_command(
+            "get_viewport_screenshot",
+            {"max_size": 1920, "filepath": path, "format": "png"},
+        )
+        bench.record("get_viewport_screenshot", time.perf_counter() - t0, "OK", path)
+    except Exception as exc:
+        bench.record("get_viewport_screenshot", time.perf_counter() - t0, "FAIL", str(exc))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default=os.getenv("BLENDER_HOST", "172.19.96.1"))
+    parser.add_argument("--port", type=int, default=int(os.getenv("BLENDER_PORT", "9876")))
+    parser.add_argument("--geojson", default=GEOJSON_DEFAULT)
+    parser.add_argument("--glb", default=GLB_DEFAULT)
+    parser.add_argument("--benchmark-out", default="")
+    parser.add_argument("--skip-import", action="store_true", help="Scene already has GeoJSON_Import")
+    args = parser.parse_args()
+
+    bench = BenchLog()
+    conn = BlenderConnection(host=args.host, port=args.port)
+
+    t0 = time.perf_counter()
+    # Fail fast if Blender is not listening (avoid ~130s WSL→Windows TCP timeout)
+    import socket as _socket
+
+    probe = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
+    probe.settimeout(10.0)
+    try:
+        probe.connect((args.host, args.port))
+        probe.close()
+    except OSError as exc:
+        bench.record("connect", time.perf_counter() - t0, "FAIL", f"{args.host}:{args.port} — {exc}")
+        if args.benchmark_out:
+            bench.write(Path(args.benchmark_out))
+        print("Blender MCP server not reachable. Open Blender GUI and Start MCP Server.")
+        return 2
+
+    if not conn.connect():
+        bench.record("connect", time.perf_counter() - t0, "FAIL", f"{args.host}:{args.port}")
+        if args.benchmark_out:
+            bench.write(Path(args.benchmark_out))
+        print("Blender MCP server not reachable. Open Blender GUI and Start MCP Server.")
+        return 2
+
+    bench.record("connect", time.perf_counter() - t0, "OK")
+
+    t0 = time.perf_counter()
+    try:
+        info = conn.send_command("get_scene_info")
+        bench.record("get_scene_info", time.perf_counter() - t0, "OK", json.dumps(info)[:200])
+    except Exception as exc:
+        bench.record("get_scene_info", time.perf_counter() - t0, "FAIL", str(exc))
+        if args.benchmark_out:
+            bench.write(Path(args.benchmark_out))
+        return 3
+
+    try:
+        phase_cleanup(conn, bench)
+        if not args.skip_import:
+            phase_import(conn, bench, args.geojson)
+        phase_heights(conn, bench)
+        phase_materials(conn, bench)
+        phase_fix_z(conn, bench)
+        phase_export_glb(conn, bench, args.glb)
+        phase_screenshot(conn, bench, SCREENSHOT_DIR)
+    finally:
+        conn.disconnect()
+
+    if args.benchmark_out:
+        bench.write(Path(args.benchmark_out))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/blender_mcp/server.py
+++ b/src/blender_mcp/server.py
@@ -17,6 +17,7 @@ from urllib.parse import urlparse
 # Import telemetry
 from .telemetry import record_startup, get_telemetry, EventType
 from .telemetry_decorator import telemetry_tool, rich_telemetry_tool
+from .socket_framing import receive_framed_bytes, send_json_message
 
 # Configure logging
 logging.basicConfig(level=logging.INFO,
@@ -59,60 +60,18 @@ class BlenderConnection:
                 self.sock = None
 
     def receive_full_response(self, sock, buffer_size=8192):
-        """Receive the complete response, potentially in multiple chunks"""
-        chunks = []
-        # Use a consistent timeout value that matches the addon's timeout
-        sock.settimeout(180.0)  # Match the addon's timeout
-        
+        """Receive one length-prefixed JSON message from the Blender addon."""
+        del buffer_size  # kept for call-site compatibility
         try:
-            while True:
-                try:
-                    chunk = sock.recv(buffer_size)
-                    if not chunk:
-                        # If we get an empty chunk, the connection might be closed
-                        if not chunks:  # If we haven't received anything yet, this is an error
-                            raise Exception("Connection closed before receiving any data")
-                        break
-                    
-                    chunks.append(chunk)
-                    
-                    # Check if we've received a complete JSON object
-                    try:
-                        data = b''.join(chunks)
-                        json.loads(data.decode('utf-8'))
-                        # If we get here, it parsed successfully
-                        logger.info(f"Received complete response ({len(data)} bytes)")
-                        return data
-                    except json.JSONDecodeError:
-                        # Incomplete JSON, continue receiving
-                        continue
-                except socket.timeout:
-                    # If we hit a timeout during receiving, break the loop and try to use what we have
-                    logger.warning("Socket timeout during chunked receive")
-                    break
-                except (ConnectionError, BrokenPipeError, ConnectionResetError) as e:
-                    logger.error(f"Socket connection error during receive: {str(e)}")
-                    raise  # Re-raise to be handled by the caller
-        except socket.timeout:
-            logger.warning("Socket timeout during chunked receive")
-        except Exception as e:
-            logger.error(f"Error during receive: {str(e)}")
-            raise
-            
-        # If we get here, we either timed out or broke out of the loop
-        # Try to use what we have
-        if chunks:
-            data = b''.join(chunks)
-            logger.info(f"Returning data after receive completion ({len(data)} bytes)")
-            try:
-                # Try to parse what we have
-                json.loads(data.decode('utf-8'))
-                return data
-            except json.JSONDecodeError:
-                # If we can't parse it, it's incomplete
-                raise Exception("Incomplete JSON response received")
-        else:
-            raise Exception("No data received")
+            data = receive_framed_bytes(sock, timeout=180.0)
+            logger.info(f"Received complete framed response ({len(data)} bytes)")
+            return data
+        except json.JSONDecodeError as e:
+            logger.error(f"Invalid JSON in framed body: {e}")
+            raise Exception("Incomplete JSON response received") from e
+        except socket.timeout as e:
+            logger.warning("Socket timeout waiting for framed response")
+            raise Exception("Incomplete JSON response received") from e
 
     def send_command(self, command_type: str, params: Dict[str, Any] = None) -> Dict[str, Any]:
         """Send a command to Blender and return the response"""

--- a/src/blender_mcp/socket_framing.py
+++ b/src/blender_mcp/socket_framing.py
@@ -1,0 +1,49 @@
+"""Length-prefixed JSON framing for Blender MCP socket protocol."""
+
+from __future__ import annotations
+
+import json
+import socket
+import struct
+from typing import Any
+
+HEADER_SIZE = 4
+HEADER_FORMAT = ">I"
+MAX_MESSAGE_BYTES = 256 * 1024 * 1024
+
+
+def pack_json_message(payload: dict[str, Any]) -> bytes:
+    body = json.dumps(payload).encode("utf-8")
+    return struct.pack(HEADER_FORMAT, len(body)) + body
+
+
+def send_json_message(sock: socket.socket, payload: dict[str, Any]) -> None:
+    sock.sendall(pack_json_message(payload))
+
+
+def receive_framed_bytes(sock: socket.socket, timeout: float = 180.0) -> bytes:
+    sock.settimeout(timeout)
+
+    length_data = b""
+    while len(length_data) < HEADER_SIZE:
+        chunk = sock.recv(HEADER_SIZE - len(length_data))
+        if not chunk:
+            raise ConnectionError("Socket closed before length prefix")
+        length_data += chunk
+
+    (length,) = struct.unpack(HEADER_FORMAT, length_data)
+    if length > MAX_MESSAGE_BYTES:
+        raise ValueError(f"Framed message too large: {length} bytes")
+
+    body = b""
+    while len(body) < length:
+        chunk = sock.recv(min(8192, length - len(body)))
+        if not chunk:
+            raise ConnectionError("Socket closed before full message body")
+        body += chunk
+
+    return body
+
+
+def receive_framed_json(sock: socket.socket, timeout: float = 180.0) -> dict[str, Any]:
+    return json.loads(receive_framed_bytes(sock, timeout).decode("utf-8"))

--- a/tests/test_socket_framing.py
+++ b/tests/test_socket_framing.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Unit tests for length-prefixed socket framing (Issue #219 cluster)."""
+
+import io
+import json
+import socket
+import struct
+import unittest
+
+from blender_mcp.socket_framing import (
+    pack_json_message,
+    receive_framed_bytes,
+    receive_framed_json,
+    send_json_message,
+)
+
+
+class MockSocket:
+    """Feed preloaded bytes through socket-like recv()."""
+
+    def __init__(self, data: bytes):
+        self._buffer = io.BytesIO(data)
+        self.timeout = None
+
+    def recv(self, size: int) -> bytes:
+        return self._buffer.read(size)
+
+    def sendall(self, data: bytes) -> None:
+        pass
+
+    def settimeout(self, timeout: float) -> None:
+        self.timeout = timeout
+
+
+class TestSocketFraming(unittest.TestCase):
+    def test_length_prefix_small_json(self):
+        payload = {"status": "success", "result": {"object_count": 3}}
+        framed = pack_json_message(payload)
+        result = receive_framed_json(MockSocket(framed))
+        self.assertEqual(result, payload)
+
+    def test_length_prefix_large_json(self):
+        payload = {"objects": [{"name": f"obj_{i}"} for i in range(10_000)]}
+        framed = pack_json_message(payload)
+        result = receive_framed_json(MockSocket(framed))
+        self.assertEqual(len(result["objects"]), 10_000)
+
+    def test_receive_partial_chunks(self):
+        payload = {"status": "ok", "data": "x" * 20_000}
+        framed = pack_json_message(payload)
+        # Split after header and mid-body to simulate TCP chunking
+        split_a = len(framed) // 3
+        split_b = (2 * len(framed)) // 3
+        chunks = [framed[:split_a], framed[split_a:split_b], framed[split_b:]]
+        mock = MockSocket(b"".join(chunks))
+        body = receive_framed_bytes(mock)
+        self.assertEqual(json.loads(body.decode()), payload)
+
+    def test_truncated_body_raises(self):
+        payload = {"status": "success"}
+        body = json.dumps(payload).encode()
+        truncated = struct.pack(">I", len(body) + 50) + body
+        with self.assertRaises(ConnectionError):
+            receive_framed_bytes(MockSocket(truncated), timeout=1.0)
+
+    def test_send_roundtrip_memory_socket(self):
+        client, server = socket.socketpair()
+        try:
+            payload = {"status": "success", "result": {"name": "Scene"}}
+            send_json_message(client, payload)
+            client.shutdown(socket.SHUT_WR)
+            received = receive_framed_json(server, timeout=5.0)
+            self.assertEqual(received, payload)
+        finally:
+            client.close()
+            server.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Fixes #219, #279, #256 (community-addon path) — adds **length-prefixed framing** to the Blender MCP TCP protocol so the MCP server knows exactly when a JSON response is complete.

## Problem

The addon sends bare JSON:

```python
client.sendall(json.dumps(response).encode("utf-8"))
```

The MCP server guesses message boundaries by looping `recv` until `json.loads` succeeds, or until a **180s** socket timeout fires and raises `Incomplete JSON response received`.

This causes:

- Truncated / ambiguous reads on payloads larger than typical TCP chunks (large `execute_blender_code` stdout, batch listings).
- Long stalls matching **~4–5 minute** MCP timeouts ([#279](https://github.com/ahujasid/blender-mcp/issues/279)).
- Confusion with **Blender Lab addon** protocol mismatch ([#256](https://github.com/ahujasid/blender-mcp/issues/256)) — documented separately in PR body.

GameFactory dogfooding (Cádiz **2355** buildings) relies on chained MCP calls; manual Blender logs prove the scene works, but automation needs a reliable transport layer.

## Solution

4-byte **big-endian length prefix** before UTF-8 JSON:

```text
[uint32 length][JSON bytes]
```

### Changes

- **`addon.py`**: `_send_framed_json()` for success/error responses.
- **`src/blender_mcp/socket_framing.py`**: shared pack/unpack helpers.
- **`src/blender_mcp/server.py`**: framed receive path.
- **`tests/test_socket_framing.py`**: small JSON, 10k-object JSON, chunked TCP simulation.
- **`scripts/benchmark_mcp_socket.py`**: N-iteration latency tool for #279 repro/post-fix validation.

## Testing

### Unit tests

```bash
uv run python -m unittest tests.test_socket_framing -v
```

All tests pass locally.

### Integration (operator)

With Blender GUI + community addon on `:9876`:

```bash
BLENDER_HOST=<wsl-gateway> uv run python scripts/benchmark_mcp_socket.py --iterations 20
```

Heavy scene checklist (Cádiz 2355): see upstream contributor notes in [GameFactory benchmark doc](https://github.com/drhiidden/developmentgames-meta/blob/main/.procontext/specific-domains/Domain-GameFactory/knowledge/oss-analysis/BENCHMARK-CADIZ-MCP-ISSUE-219.md) (evidence bundle).

| Command | Before (expected) | After (target) |
|---------|-------------------|----------------|
| `get_scene_info` default | OK | OK |
| `execute_code` large stdout | Fail / timeout | OK |
| 20× sequential commands | Degrading latency (#279) | Stable p50 |

## Impact

- Fixes incomplete JSON / timeout class for **large responses** on community stack.
- Enables batch automation (GeoJSON → GLB via MCP).
- **Breaking change:** upgrade **addon + MCP server together**.

## Related

- Complements #152 / WSL host binding (GameFactory PR #291).
- Does not replace Blender Lab bridge; users on official Lab addon should keep using [blender-lab-mcp-bridge](https://github.com/BI-Blitzer/blender-lab-mcp-bridge).

## Future work

- Single-flight command queue on addon (`bpy.app.timers` overlap).
- Optional progress messages for multi-minute Blender ops.
