### PR TITLE
fix: update Hunyuan3D to Tencent Cloud AI3D API 3.0

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -2214,10 +2214,10 @@ class BlenderMCPServer:
                 return {"error": "Prompt or Image is required"}
             if text_prompt and image:
                 return {"error": "Prompt and Image cannot be provided simultaneously"}
-            # Fixed parameter configuration
-            service = "hunyuan"
-            action = "SubmitHunyuanTo3DJob"
-            version = "2023-09-01"
+            # Updated to Tencent Cloud AI3D API 3.0 (2025-05-13)
+            service = "ai3d"
+            action = "SubmitHunyuanTo3DProJob"
+            version = "2025-05-13"
             region = "ap-guangzhou"
 
             headParams={
@@ -2227,14 +2227,12 @@ class BlenderMCPServer:
             }
 
             # Constructing request parameters
-            data = {
-                "Num": 1  # The current API limit is only 1
-            }
+            data = {}
 
             # Handling text prompts
             if text_prompt:
-                if len(text_prompt) > 200:
-                    return {"error": "Prompt exceeds 200 characters limit"}
+                if len(text_prompt) > 1024:
+                    return {"error": "Prompt exceeds 1024 characters limit"}
                 data["Prompt"] = text_prompt
 
             # Handling image
@@ -2362,9 +2360,10 @@ class BlenderMCPServer:
             if not job_id:
                 return {"error": "JobId is required"}
             
-            service = "hunyuan"
-            action = "QueryHunyuanTo3DJob"
-            version = "2023-09-01"
+            # Updated to Tencent Cloud AI3D API 3.0 (2025-05-13)
+            service = "ai3d"
+            action = "QueryHunyuanTo3DProJob"
+            version = "2025-05-13"
             region = "ap-guangzhou"
 
             headParams={
@@ -2397,74 +2396,91 @@ class BlenderMCPServer:
     def import_generated_asset_hunyuan(self, *args, **kwargs):
         return self.import_generated_asset_hunyuan_ai(*args, **kwargs)
             
-    def import_generated_asset_hunyuan_ai(self, name: str , zip_file_url: str):
+    def import_generated_asset_hunyuan_ai(self, name: str, zip_file_url: str):
         if not zip_file_url:
-            return {"error": "Zip file not found"}
+            return {"error": "No file URL provided"}
         
         # Validate URL
         if not re.match(r'^https?://', zip_file_url, re.IGNORECASE):
             return {"error": "Invalid URL format. Must start with http:// or https://"}
         
-        # Create a temporary directory
+        # Prefer GLB (self-contained with materials) over OBJ/ZIP (API 3.0 returns .glb URLs)
+        if zip_file_url.endswith('.glb') or '.glb?' in zip_file_url:
+            temp_dir = tempfile.mkdtemp(prefix="hunyuan_glb_")
+            glb_path = osp.join(temp_dir, "model.glb")
+            try:
+                glb_response = requests.get(zip_file_url, stream=True)
+                glb_response.raise_for_status()
+                with open(glb_path, "wb") as f:
+                    for chunk in glb_response.iter_content(chunk_size=8192):
+                        f.write(chunk)
+                bpy.ops.import_scene.gltf(filepath=glb_path)
+                imported_objs = [obj for obj in bpy.context.selected_objects if obj.type == 'MESH']
+                if not imported_objs:
+                    return {"succeed": False, "error": "No mesh objects imported from GLB"}
+                obj = imported_objs[0]
+                if name:
+                    obj.name = name
+                result = {
+                    "name": obj.name, "type": obj.type,
+                    "location": [obj.location.x, obj.location.y, obj.location.z],
+                    "rotation": [obj.rotation_euler.x, obj.rotation_euler.y, obj.rotation_euler.z],
+                    "scale": [obj.scale.x, obj.scale.y, obj.scale.z],
+                }
+                if obj.type == "MESH":
+                    result["world_bounding_box"] = self._get_aabb(obj)
+                return {"succeed": True, **result}
+            except Exception as e:
+                return {"succeed": False, "error": str(e)}
+            finally:
+                try:
+                    if os.path.exists(glb_path):
+                        os.remove(glb_path)
+                except Exception:
+                    pass
+
+        # Fallback: ZIP/OBJ import (legacy)
         temp_dir = tempfile.mkdtemp(prefix="tencent_obj_")
         zip_file_path = osp.join(temp_dir, "model.zip")
         obj_file_path = osp.join(temp_dir, "model.obj")
-        mtl_file_path = osp.join(temp_dir, "model.mtl")
-
         try:
-            # Download ZIP file
             zip_response = requests.get(zip_file_url, stream=True)
             zip_response.raise_for_status()
             with open(zip_file_path, "wb") as f:
                 for chunk in zip_response.iter_content(chunk_size=8192):
                     f.write(chunk)
-
-            # Unzip the ZIP
             with zipfile.ZipFile(zip_file_path, "r") as zip_ref:
                 zip_ref.extractall(temp_dir)
-
-            # Find the .obj file (there may be multiple, assuming the main file is model.obj)
             for file in os.listdir(temp_dir):
                 if file.endswith(".obj"):
                     obj_file_path = osp.join(temp_dir, file)
-
             if not osp.exists(obj_file_path):
                 return {"succeed": False, "error": "OBJ file not found after extraction"}
-
-            # Import obj file
             if bpy.app.version>=(4, 0, 0):
                 bpy.ops.wm.obj_import(filepath=obj_file_path)
             else:
                 bpy.ops.import_scene.obj(filepath=obj_file_path)
-
             imported_objs = [obj for obj in bpy.context.selected_objects if obj.type == 'MESH']
             if not imported_objs:
                 return {"succeed": False, "error": "No mesh objects imported"}
-
             obj = imported_objs[0]
             if name:
                 obj.name = name
-
             result = {
-                "name": obj.name,
-                "type": obj.type,
+                "name": obj.name, "type": obj.type,
                 "location": [obj.location.x, obj.location.y, obj.location.z],
                 "rotation": [obj.rotation_euler.x, obj.rotation_euler.y, obj.rotation_euler.z],
                 "scale": [obj.scale.x, obj.scale.y, obj.scale.z],
             }
-
             if obj.type == "MESH":
-                bounding_box = self._get_aabb(obj)
-                result["world_bounding_box"] = bounding_box
-
+                result["world_bounding_box"] = self._get_aabb(obj)
             return {"succeed": True, **result}
         except Exception as e:
             return {"succeed": False, "error": str(e)}
         finally:
-            #  Clean up temporary zip and obj, save texture and mtl
             try:
                 if os.path.exists(zip_file_path):
-                    os.remove(zip_file_path) 
+                    os.remove(zip_file_path)
                 if os.path.exists(obj_file_path):
                     os.remove(obj_file_path)
             except Exception as e:


### PR DESCRIPTION
## Problem

The Hunyuan3D official API integration uses the deprecated API (service=hunyuan, version=2023-09-01, SubmitHunyuanTo3DJob). Calling it returns ResourceInsufficient because Tencent has migrated to API 3.0.

## Changes

- service: hunyuan -> ai3d
- action: SubmitHunyuanTo3DJob -> SubmitHunyuanTo3DProJob
- action: QueryHunyuanTo3DJob -> QueryHunyuanTo3DProJob  
- version: 2023-09-01 -> 2025-05-13
- Remove deprecated Num parameter
- Increase prompt limit from 200 to 1024 chars (per new API docs)
- Add GLB import support: new API returns .glb URLs with embedded PBR materials, which are preferred over legacy .obj/.zip

## Tested

- Successfully submitted a text-to-3D job and received a DONE result with GLB + OBJ files
- GLB import into Blender 4.4 works correctly with materials
- Ref: https://cloud.tencent.com/document/product/1804/123447
