### PR TITLE
Document that Hunyuan3D local api mode needs your own server

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ Once the config file has been set on Claude, and the addon is running on Blender
 - Execute any Python code in Blender
 - Download the right models, assets and HDRIs through [Poly Haven](https://polyhaven.com/)
 - AI generated 3D models through [Hyper3D Rodin](https://hyper3d.ai/)
+- AI generated 3D models through [Hunyuan3D](https://github.com/Tencent-Hunyuan/Hunyuan3D-2) (Tencent Cloud, or your own self-hosted server)
 
 
 ### Example Commands
@@ -285,6 +286,15 @@ Here are some examples of what you can ask Claude to do:
 ## Hyper3D integration
 
 Hyper3D's free trial key allows you to generate a limited number of models per day. If the daily limit is reached, you can wait for the next day's reset or obtain your own key from hyper3d.ai and fal.ai.
+
+## Hunyuan3D integration
+
+Hunyuan3D has two modes, selected by the **Hunyuan3D Mode** dropdown in the BlenderMCP sidebar panel:
+
+- **`official api`** — Tencent Cloud. Requires a SecretId and SecretKey, and bills per job.
+- **`local api`** — your own self-hosted Hunyuan3D inference server. This is the default.
+
+**`local api` mode requires you to run that server yourself.** BlenderMCP is only the client: it POSTs to `<API URL>/generate` and imports the GLB it gets back, but it does not provide, bundle or start an inference server. The **API URL** field defaults to `http://localhost:8081`, so if nothing is listening there, generation fails with a connection error.
 
 ## Persistent API credentials
 


### PR DESCRIPTION
Follow-up to #301, as offered there. Docs only — no behaviour change, and independent of that PR (branched from `main`, touches only `README.md`).

## Problem

The README documents the **Hunyuan3D API URL** field and `BLENDERMCP_HUNYUAN3D_API_URL`, but never says that `local api` mode — which is the **default** — expects you to run your own inference server.

Combined with `blendermcp_hunyuan3d_api_url` defaulting to `http://localhost:8081` (`addon.py:2773`), ticking the Hunyuan3D checkbox and asking for a model gives you a bare connection error with nothing pointing at the actual cause. I hit this and only worked it out by reading `create_hunyuan_job_local_site`.

## Change

- New **Hunyuan3D integration** section beside the existing Hyper3D one, stating what each mode needs: `official api` wants Tencent Cloud credentials and bills per job; `local api` wants a server you host, and BlenderMCP is only the client that POSTs to `<API URL>/generate` and imports the returned GLB.
- Added Hunyuan3D to the **Capabilities** list next to Hyper3D Rodin, where it was missing despite being a shipped feature.

Every claim is drawn from the source: the `/generate` POST and GLB import at `addon.py:2318`–`2335`, the mode enum and its `LOCAL_API` default at `addon.py:2747`, and the URL default at `addon.py:2773`.

I deliberately did **not** document how to stand up a Hunyuan3D server — that belongs upstream with the model, and pinning install steps here would rot. The section just makes clear that one is required and that BlenderMCP won't provide it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
