### PR TITLE
fix: validate input_image_urls instead of input_image_paths in MAIN_SITE mode

### DIFF
--- a/src/blender_mcp/server.py
+++ b/src/blender_mcp/server.py
@@ -915,7 +915,7 @@ def generate_hyper3d_model_via_images(
                     (Path(path).suffix, base64.b64encode(f.read()).decode("ascii"))
                 )
     elif input_image_urls is not None:
-        if not all(urlparse(i) for i in input_image_paths):
+        if not all(urlparse(i) for i in input_image_urls):
             return "Error: not all image URLs are valid!"
         images = input_image_urls.copy()
     try:


### PR DESCRIPTION
## Problem

In `generate_hyper3d_model_via_images` (`src/blender_mcp/server.py`), the `input_image_urls` branch validates the wrong variable:

```python
elif input_image_urls is not None:
    if not all(urlparse(i) for i in input_image_paths):  # None in this branch
```

The function returns early if both arguments are provided, so reaching this branch guarantees `input_image_paths is None`. Every call that passes `input_image_urls` therefore raises `TypeError: 'NoneType' object is not iterable` before any request is made — the URL path of this tool is unreachable.

## Fix

One-line change to iterate `input_image_urls`.

Note: `all(urlparse(i) for i in ...)` is a weak check regardless, since `urlparse` returns a truthy `ParseResult` for any non-empty string. Tightening it (e.g. asserting `scheme in ("http", "https")`) felt out of scope for a bug fix — happy to include it if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)