### PR TITLE
fix: reject nonpositive integer bounding boxes

### DIFF
--- a/src/blender_mcp/server.py
+++ b/src/blender_mcp/server.py
@@ -841,10 +841,10 @@ def download_sketchfab_model(
 def _process_bbox(original_bbox: list[float] | list[int] | None) -> list[int] | None:
     if original_bbox is None:
         return None
-    if all(isinstance(i, int) for i in original_bbox):
-        return original_bbox
     if any(i<=0 for i in original_bbox):
         raise ValueError("Incorrect number range: bbox must be bigger than zero!")
+    if all(isinstance(i, int) for i in original_bbox):
+        return original_bbox
     return [int(float(i) / max(original_bbox) * 100) for i in original_bbox] if original_bbox else None
 
 @mcp.tool()

--- a/test_process_bbox_validation.py
+++ b/test_process_bbox_validation.py
@@ -1,0 +1,9 @@
+import pytest
+
+from blender_mcp.server import _process_bbox
+
+
+@pytest.mark.parametrize("bbox", ([0, 1, 1], [-1, 1, 1]))
+def test_process_bbox_rejects_nonpositive_integers(bbox):
+    with pytest.raises(ValueError, match="bbox must be bigger than zero"):
+        _process_bbox(bbox)


### PR DESCRIPTION
## Summary

- Fixes: Hyper3D image or text generation accepts integer bounding-box ratios containing zero or negative values and forwards them to Blender, while equivalent float inputs are rejected locally as invalid.
- Root cause: _process_bbox returns every all-integer list before running the existing nonpositive-value check, so the validation is reachable only for float-containing lists.

## Regression evidence

- Before: `uv run --with pytest pytest test_process_bbox_validation.py -q` exited `1`

- After: `uv run --with pytest pytest test_process_bbox_validation.py -q` exited `0`

## Verification

- `uv run --with pytest pytest -q`
- `uv run python -m compileall -f src addon.py main.py test_set_texture_version_guard.py test_process_bbox_validation.py`
- `uv build`
- `git diff --cached --check`

## Scope

- 2 files changed, +11 / -2 lines
