### PR TITLE
fix: reconnect when the cached socket has gone stale

### DIFF
--- a/src/blender_mcp/server.py
+++ b/src/blender_mcp/server.py
@@ -41,8 +41,13 @@ class BlenderConnection:
     def connect(self) -> bool:
         """Connect to the Blender addon socket server"""
         if self.sock:
-            return True
-            
+            if not self._peer_closed():
+                return True
+            # The cached socket outlived the connection Blender had open for it,
+            # so drop it rather than writing into a dead handle.
+            logger.info("Cached socket is stale; reconnecting to Blender")
+            self._close_socket()
+
         try:
             self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             self.sock.connect((self.host, self.port))
@@ -62,6 +67,42 @@ class BlenderConnection:
                 logger.error(f"Error disconnecting from Blender: {str(e)}")
             finally:
                 self.sock = None
+
+    def _close_socket(self):
+        """Drop the cached socket without logging an error if it is already dead."""
+        if self.sock:
+            try:
+                self.sock.close()
+            except OSError:
+                pass
+            finally:
+                self.sock = None
+
+    def _peer_closed(self) -> bool:
+        """Report whether the cached socket has been closed on Blender's side.
+
+        The connection is kept open across commands, so it can go away while the
+        client sits idle - the addon's handler thread ends, Blender restarts, or
+        the machine sleeps. A non-blocking peek distinguishes 'idle but alive'
+        (no data pending) from 'closed' (orderly EOF or a reset), which lets
+        connect() replace a dead socket before anything is written to it.
+        """
+        if not self.sock:
+            return True
+
+        try:
+            self.sock.setblocking(False)
+            try:
+                # An orderly close from the peer surfaces as an empty read.
+                return self.sock.recv(1, socket.MSG_PEEK) == b''
+            except BlockingIOError:
+                return False  # nothing pending: idle, still connected
+            except OSError:
+                return True   # reset, aborted, or otherwise unusable
+            finally:
+                self.sock.setblocking(True)
+        except OSError:
+            return True
 
     def receive_full_response(self, sock, buffer_size=8192):
         """Receive the complete response, potentially in multiple chunks"""
@@ -127,8 +168,30 @@ class BlenderConnection:
         with self._lock:
             return self._send_command_locked(command_type, params)
 
+    def _send_payload(self, payload: bytes) -> None:
+        """Write one command to Blender, reconnecting once if the socket is dead.
+
+        Retrying is only safe on the send side: a failed send means Blender never
+        received the command, so re-sending cannot apply it twice. A failure while
+        receiving is deliberately not retried - the command may already have run.
+        """
+        try:
+            self.sock.sendall(payload)
+            return
+        except socket.timeout:
+            raise
+        except OSError as e:
+            logger.warning(f"Send failed on cached socket ({e}); reconnecting and retrying once")
+
+        self._close_socket()
+        if not self.connect():
+            raise ConnectionError("Not connected to Blender")
+        self.sock.sendall(payload)
+
     def _send_command_locked(self, command_type: str, params: Dict[str, Any] = None) -> Dict[str, Any]:
-        if not self.sock and not self.connect():
+        # connect() also validates a cached socket, so this replaces a stale one
+        # before the command is written rather than after it fails.
+        if not self.connect():
             raise ConnectionError("Not connected to Blender")
 
         command = {
@@ -141,7 +204,7 @@ class BlenderConnection:
             logger.info(f"Sending command: {command_type} with params: {params}")
             
             # Send the command
-            self.sock.sendall(json.dumps(command).encode('utf-8'))
+            self._send_payload(json.dumps(command).encode('utf-8'))
             logger.info(f"Command sent, waiting for response...")
             
             # Set a timeout for receiving - use the same timeout as in receive_full_response
@@ -166,9 +229,12 @@ class BlenderConnection:
             self.sock = None
             raise Exception("Timeout waiting for Blender response - try simplifying your request. If Blender is running headless (blender -b), commands never execute; run Blender with a GUI or via 'xvfb-run -a blender' instead")
         except (ConnectionError, BrokenPipeError, ConnectionResetError) as e:
+            # Reaching here means the connection dropped while waiting for the
+            # response, so the command may already have taken effect in Blender.
+            # Not retried for that reason - the next command reconnects.
             logger.error(f"Socket connection error: {str(e)}")
-            self.sock = None
-            raise Exception(f"Connection to Blender lost: {str(e)}")
+            self._close_socket()
+            raise Exception(f"Connection to Blender lost while awaiting a response: {str(e)}")
         except json.JSONDecodeError as e:
             logger.error(f"Invalid JSON response from Blender: {str(e)}")
             # Try to log what was received

--- a/test_stale_socket_reconnect.py
+++ b/test_stale_socket_reconnect.py
@@ -1,0 +1,143 @@
+"""Behavioural tests for recovering from a stale cached socket.
+
+BlenderConnection keeps one socket open across commands. If Blender closes its
+end while the client is idle, the cached handle is dead and the next command used
+to fail with "Connection to Blender lost" (WinError 10054 on Windows) even though
+the command never reached Blender. These tests drive a fake addon server over
+loopback to cover that path without needing Blender.
+"""
+import json
+import pathlib
+import socket
+import sys
+import threading
+import time
+
+sys.path.insert(0, str(pathlib.Path(__file__).with_name("src")))
+
+from blender_mcp.server import BlenderConnection  # noqa: E402
+
+
+class FakeAddonServer:
+    """Minimal stand-in for the addon's socket server."""
+
+    def __init__(self):
+        self._listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._listener.bind(("localhost", 0))
+        self._listener.listen(5)
+        self.port = self._listener.getsockname()[1]
+        self.connections = []
+        self.commands = []
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._serve, daemon=True)
+        self._thread.start()
+
+    def _serve(self):
+        while not self._stop.is_set():
+            try:
+                client, _ = self._listener.accept()
+            except OSError:
+                return
+            self.connections.append(client)
+            threading.Thread(target=self._handle, args=(client,), daemon=True).start()
+
+    def _handle(self, client):
+        buffer = b""
+        while not self._stop.is_set():
+            try:
+                data = client.recv(8192)
+            except OSError:
+                return
+            if not data:
+                return
+            buffer += data
+            try:
+                command = json.loads(buffer.decode("utf-8"))
+            except json.JSONDecodeError:
+                continue
+            buffer = b""
+            self.commands.append(command)
+            reply = {"status": "success", "result": {"echoed": command["type"]}}
+            try:
+                client.sendall(json.dumps(reply).encode("utf-8"))
+            except OSError:
+                return
+
+    def wait_for_connections(self, count, timeout=5.0):
+        """Block until the accept loop has picked up `count` connections."""
+        deadline = time.monotonic() + timeout
+        while len(self.connections) < count:
+            if time.monotonic() > deadline:
+                raise AssertionError(
+                    f"expected {count} connection(s), saw {len(self.connections)}"
+                )
+            time.sleep(0.01)
+
+    def drop_current_connection(self):
+        """Close the server side of the live connection, as Blender does on idle."""
+        self.wait_for_connections(len(self.connections) or 1)
+        self.connections[-1].close()
+
+    def close(self):
+        self._stop.set()
+        self._listener.close()
+
+
+def test_peer_closed_is_false_while_idle():
+    server = FakeAddonServer()
+    conn = BlenderConnection(host="localhost", port=server.port)
+    try:
+        assert conn.connect()
+        # An open connection with no pending data must not be mistaken for a dead one.
+        assert conn._peer_closed() is False
+    finally:
+        conn.disconnect()
+        server.close()
+
+
+def test_peer_closed_detects_server_side_close():
+    server = FakeAddonServer()
+    conn = BlenderConnection(host="localhost", port=server.port)
+    try:
+        assert conn.connect()
+        server.drop_current_connection()
+        # The FIN has to land before the peek can see it.
+        deadline = time.monotonic() + 5.0
+        while not conn._peer_closed():
+            assert time.monotonic() < deadline, "close was never observed"
+            time.sleep(0.01)
+    finally:
+        conn.disconnect()
+        server.close()
+
+
+def test_command_after_idle_close_reconnects():
+    """The regression: a command issued after the server dropped the connection."""
+    server = FakeAddonServer()
+    conn = BlenderConnection(host="localhost", port=server.port)
+    try:
+        assert conn.send_command("get_scene_info") == {"echoed": "get_scene_info"}
+
+        server.drop_current_connection()
+
+        # Previously raised "Connection to Blender lost"; must now just work.
+        assert conn.send_command("execute_code") == {"echoed": "execute_code"}
+        server.wait_for_connections(2)
+        assert [c["type"] for c in server.commands] == ["get_scene_info", "execute_code"]
+    finally:
+        conn.disconnect()
+        server.close()
+
+
+def test_command_is_not_sent_twice_on_reconnect():
+    """A reconnect must re-send the command once, never duplicate it."""
+    server = FakeAddonServer()
+    conn = BlenderConnection(host="localhost", port=server.port)
+    try:
+        conn.send_command("first")
+        server.drop_current_connection()
+        conn.send_command("mutating_command")
+        assert [c["type"] for c in server.commands].count("mutating_command") == 1
+    finally:
+        conn.disconnect()
+        server.close()


### PR DESCRIPTION
### Problem

`BlenderConnection` keeps one socket open and reuses it for every command, but `connect()` returned early on any non-`None` socket:

```python
def connect(self) -> bool:
    if self.sock:
        return True    # never checks whether the socket is still usable
```

When Blender closes its end while the client is idle, the cached handle is dead. The next command is written into it and fails with `Connection to Blender lost` — `[WinError 10054] An existing connection was forcibly closed by the remote host` on Windows. The existing handler sets `self.sock = None` and re-raises, so the *following* command reconnects and works.

The user-visible symptom is one spurious failure after every idle gap, which reads as a Blender problem but is not: the scene is provably untouched afterwards, because the command never reached Blender.

### Fix

- `connect()` validates a cached socket with a non-blocking `MSG_PEEK` before reusing it. This distinguishes *idle but alive* (`BlockingIOError`, nothing pending) from *closed* (empty read, or a reset/abort `OSError`), and replaces a dead socket before anything is written to it.
- `_send_payload()` additionally reconnects and retries **once** if the send itself fails. This is safe precisely because a failed send proves the command never arrived.
- A drop **while awaiting the response** is deliberately left fatal. At that point the command may already have executed in Blender, so retrying it could apply a mutation twice. Only the message changed, to say when the drop happened.

### Tests

`test_stale_socket_reconnect.py` drives a fake addon server over loopback — no Blender required, ~1s runtime:

- `_peer_closed()` is `False` for a live idle connection and `True` once the server closes its end
- a command issued after the server dropped the connection succeeds transparently
- the re-sent command reaches the server exactly once, never twice

`test_command_after_idle_close_reconnects` reproduces the original `[WinError 10054]` when run against unpatched `server.py`, and passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)