### PR TITLE
feat: support WSL networking

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,12 +129,23 @@ The following environment variables can be used to configure the Blender connect
 
 - `BLENDER_HOST`: Host address for Blender socket server (default: "localhost")
 - `BLENDER_PORT`: Port number for Blender socket server (default: 9876)
+- `WSL_NETWORKING`: Set to `true` only when the MCP client runs in WSL and Blender runs on Windows. The Blender add-on then listens on `0.0.0.0` instead of `localhost` (default: `false`).
 
 Example:
 ```bash
 export BLENDER_HOST='host.docker.internal'
 export BLENDER_PORT=9876
 ```
+
+#### WSL and Windows Blender
+
+When Blender runs on Windows and the MCP client runs in WSL, set `WSL_NETWORKING=true` in the Windows environment that launches Blender, then restart Blender. Configure the MCP client to use the Windows host IP, which is the WSL default gateway:
+
+```bash
+ip route show default
+```
+
+Use the address following `via` as `BLENDER_HOST` and allow Blender through Windows Firewall on private networks. `WSL_NETWORKING` is disabled by default so non-WSL installations remain bound to localhost.
 
 ### Claude for Desktop Integration
 

--- a/addon.py
+++ b/addon.py
@@ -43,9 +43,16 @@ def get_blendermcp_addon_preferences(context=None):
     addon = context.preferences.addons.get(__name__)
     return addon.preferences if addon else None
 
+
+def get_server_host():
+    """Keep the server local unless WSL needs to reach Blender over the network."""
+    wsl_networking = os.getenv("WSL_NETWORKING", "").lower()
+    return "0.0.0.0" if wsl_networking in {"1", "true", "yes", "on"} else "localhost"
+
+
 class BlenderMCPServer:
-    def __init__(self, host='localhost', port=9876):
-        self.host = host
+    def __init__(self, host=None, port=9876):
+        self.host = host or get_server_host()
         self.port = port
         self.running = False
         self.socket = None


### PR DESCRIPTION
I like to use a WSL terminal, but Blender obviously runs in Windows.
This optional env variable enables support for networking with this setup