### PR TITLE
fix: report disabled Sketchfab integration accurately

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -1629,7 +1629,7 @@ class BlenderMCPServer:
         api_key = self._get_sketchfab_api_key()
 
         # Test the API key if present
-        if api_key:
+        if api_key and enabled:
             try:
                 headers = {
                     "Authorization": f"Token {api_key}"

--- a/test_sketchfab_status.py
+++ b/test_sketchfab_status.py
@@ -1,0 +1,89 @@
+"""Regression coverage for Sketchfab availability reporting."""
+import importlib.util
+import pathlib
+import sys
+import types
+
+ADDON = pathlib.Path(__file__).with_name("addon.py")
+
+
+def _load_addon(monkeypatch, scene):
+    bpy = types.ModuleType("bpy")
+    bpy.context = types.SimpleNamespace(scene=scene)
+    bpy.types = types.SimpleNamespace(
+        AddonPreferences=object,
+        Operator=object,
+        Panel=object,
+        Scene=type("Scene", (), {}),
+    )
+
+    props = types.ModuleType("bpy.props")
+    for name in ("BoolProperty", "EnumProperty", "FloatProperty", "IntProperty", "StringProperty"):
+        setattr(props, name, lambda **_kwargs: None)
+    bpy.props = props
+
+    monkeypatch.setitem(sys.modules, "bpy", bpy)
+    monkeypatch.setitem(sys.modules, "bpy.props", props)
+    monkeypatch.setitem(sys.modules, "mathutils", types.ModuleType("mathutils"))
+
+    requests = types.ModuleType("requests")
+    requests.utils = types.SimpleNamespace(default_headers=dict)
+    requests.exceptions = types.SimpleNamespace(Timeout=TimeoutError)
+    monkeypatch.setitem(sys.modules, "requests", requests)
+
+    spec = importlib.util.spec_from_file_location("blender_mcp_addon_test", ADDON)
+    addon = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(addon)
+    return addon
+
+
+def _scene(sketchfab_enabled):
+    return types.SimpleNamespace(
+        blendermcp_use_polyhaven=False,
+        blendermcp_use_hyper3d=False,
+        blendermcp_use_hunyuan3d=False,
+        blendermcp_use_sketchfab=sketchfab_enabled,
+    )
+
+
+def test_disabled_sketchfab_does_not_report_a_saved_key_as_ready(monkeypatch):
+    addon = _load_addon(monkeypatch, _scene(sketchfab_enabled=False))
+    server = addon.BlenderMCPServer()
+    monkeypatch.setattr(server, "_get_sketchfab_api_key", lambda: "saved-key")
+
+    def request_should_not_run(*_args, **_kwargs):
+        raise AssertionError("must not validate a disabled integration")
+
+    monkeypatch.setattr(
+        addon.requests,
+        "get",
+        request_should_not_run,
+        raising=False,
+    )
+
+    status = server.get_sketchfab_status()
+    command = server._execute_command_internal({"type": "search_sketchfab_models"})
+
+    assert status["enabled"] is False
+    assert "currently disabled" in status["message"]
+    assert command == {"status": "error", "message": "Unknown command type: search_sketchfab_models"}
+
+
+def test_enabled_sketchfab_reports_a_valid_key_as_ready(monkeypatch):
+    addon = _load_addon(monkeypatch, _scene(sketchfab_enabled=True))
+    server = addon.BlenderMCPServer()
+    monkeypatch.setattr(server, "_get_sketchfab_api_key", lambda: "saved-key")
+
+    class Response:
+        status_code = 200
+
+        @staticmethod
+        def json():
+            return {"username": "artist"}
+
+    monkeypatch.setattr(addon.requests, "get", lambda *_args, **_kwargs: Response(), raising=False)
+
+    assert server.get_sketchfab_status() == {
+        "enabled": True,
+        "message": "Sketchfab integration is enabled and ready to use. Logged in as: artist",
+    }


### PR DESCRIPTION
## Summary

- Keep the Sketchfab readiness status aligned with the enabled integration.
- Add regression coverage for the add-on status and command dispatch.

## Verification

- `uv run --with pytest pytest -q` — 8 passed
- `uv run --with ruff ruff check test_sketchfab_status.py`
- `uv run python -m compileall -q addon.py src test_sketchfab_status.py test_set_texture_version_guard.py`
