### PR TITLE
fix: sync bundled Hunyuan addon, harden zip import, bump 1.8.3

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -3048,9 +3048,10 @@ class BlenderMCPServer:
         # Validate URL
         if not re.match(r'^https?://', zip_file_url, re.IGNORECASE):
             return {"error": "Invalid URL format. Must start with http:// or https://"}
-        
+
         # Prefer GLB (self-contained with materials) over OBJ/ZIP (API 3.0 returns .glb URLs)
-        if zip_file_url.endswith('.glb') or '.glb?' in zip_file_url:
+        url_path = zip_file_url.split('?', 1)[0].split('#', 1)[0].lower()
+        if url_path.endswith('.glb'):
             temp_dir = tempfile.mkdtemp(prefix="hunyuan_glb_")
             glb_path = osp.join(temp_dir, "model.glb")
             try:
@@ -3078,11 +3079,8 @@ class BlenderMCPServer:
             except Exception as e:
                 return {"succeed": False, "error": str(e)}
             finally:
-                try:
-                    if os.path.exists(glb_path):
-                        os.remove(glb_path)
-                except Exception:
-                    pass
+                with suppress(Exception):
+                    shutil.rmtree(temp_dir)
 
         # Fallback: ZIP/OBJ import (legacy)
         temp_dir = tempfile.mkdtemp(prefix="tencent_obj_")
@@ -3095,6 +3093,22 @@ class BlenderMCPServer:
                 for chunk in zip_response.iter_content(chunk_size=8192):
                     f.write(chunk)
             with zipfile.ZipFile(zip_file_path, "r") as zip_ref:
+                # Mirror the Sketchfab zip-slip checks before extractall.
+                abs_temp_dir = os.path.abspath(temp_dir)
+                for file_info in zip_ref.infolist():
+                    file_path = file_info.filename
+                    target_path = os.path.join(temp_dir, os.path.normpath(file_path))
+                    abs_target_path = os.path.abspath(target_path)
+                    if not abs_target_path.startswith(abs_temp_dir + os.sep) and abs_target_path != abs_temp_dir:
+                        return {
+                            "succeed": False,
+                            "error": "Security issue: Zip contains files with path traversal attempt",
+                        }
+                    if ".." in file_path:
+                        return {
+                            "succeed": False,
+                            "error": "Security issue: Zip contains files with directory traversal sequence",
+                        }
                 zip_ref.extractall(temp_dir)
             for file in os.listdir(temp_dir):
                 if file.endswith(".obj"):
@@ -3123,13 +3137,8 @@ class BlenderMCPServer:
         except Exception as e:
             return {"succeed": False, "error": str(e)}
         finally:
-            try:
-                if os.path.exists(zip_file_path):
-                    os.remove(zip_file_path)
-                if os.path.exists(obj_file_path):
-                    os.remove(obj_file_path)
-            except Exception as e:
-                print(f"Failed to clean up temporary directory {temp_dir}: {e}")
+            with suppress(Exception):
+                shutil.rmtree(temp_dir)
     #endregion
 
 # Blender Addon Preferences

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blender-mcp"
-version = "1.8.1"
+version = "1.8.3"
 description = "Blender integration through the Model Context Protocol"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/blender_mcp/bundled/addon.py
+++ b/src/blender_mcp/bundled/addon.py
@@ -2274,7 +2274,7 @@ class BlenderMCPServer:
         api_key = self._get_sketchfab_api_key()
 
         # Test the API key if present
-        if api_key:
+        if api_key and enabled:
             try:
                 headers = {
                     "Authorization": f"Token {api_key}"
@@ -2859,10 +2859,10 @@ class BlenderMCPServer:
                 return {"error": "Prompt or Image is required"}
             if text_prompt and image:
                 return {"error": "Prompt and Image cannot be provided simultaneously"}
-            # Fixed parameter configuration
-            service = "hunyuan"
-            action = "SubmitHunyuanTo3DJob"
-            version = "2023-09-01"
+            # Updated to Tencent Cloud AI3D API 3.0 (2025-05-13)
+            service = "ai3d"
+            action = "SubmitHunyuanTo3DProJob"
+            version = "2025-05-13"
             region = "ap-guangzhou"
 
             headParams={
@@ -2872,14 +2872,12 @@ class BlenderMCPServer:
             }
 
             # Constructing request parameters
-            data = {
-                "Num": 1  # The current API limit is only 1
-            }
+            data = {}
 
             # Handling text prompts
             if text_prompt:
-                if len(text_prompt) > 200:
-                    return {"error": "Prompt exceeds 200 characters limit"}
+                if len(text_prompt) > 1024:
+                    return {"error": "Prompt exceeds 1024 characters limit"}
                 data["Prompt"] = text_prompt
 
             # Handling image
@@ -3007,9 +3005,10 @@ class BlenderMCPServer:
             if not job_id:
                 return {"error": "JobId is required"}
             
-            service = "hunyuan"
-            action = "QueryHunyuanTo3DJob"
-            version = "2023-09-01"
+            # Updated to Tencent Cloud AI3D API 3.0 (2025-05-13)
+            service = "ai3d"
+            action = "QueryHunyuanTo3DProJob"
+            version = "2025-05-13"
             region = "ap-guangzhou"
 
             headParams={
@@ -3042,78 +3041,104 @@ class BlenderMCPServer:
     def import_generated_asset_hunyuan(self, *args, **kwargs):
         return self.import_generated_asset_hunyuan_ai(*args, **kwargs)
             
-    def import_generated_asset_hunyuan_ai(self, name: str , zip_file_url: str):
+    def import_generated_asset_hunyuan_ai(self, name: str, zip_file_url: str):
         if not zip_file_url:
-            return {"error": "Zip file not found"}
+            return {"error": "No file URL provided"}
         
         # Validate URL
         if not re.match(r'^https?://', zip_file_url, re.IGNORECASE):
             return {"error": "Invalid URL format. Must start with http:// or https://"}
-        
-        # Create a temporary directory
+
+        # Prefer GLB (self-contained with materials) over OBJ/ZIP (API 3.0 returns .glb URLs)
+        url_path = zip_file_url.split('?', 1)[0].split('#', 1)[0].lower()
+        if url_path.endswith('.glb'):
+            temp_dir = tempfile.mkdtemp(prefix="hunyuan_glb_")
+            glb_path = osp.join(temp_dir, "model.glb")
+            try:
+                glb_response = requests.get(zip_file_url, stream=True)
+                glb_response.raise_for_status()
+                with open(glb_path, "wb") as f:
+                    for chunk in glb_response.iter_content(chunk_size=8192):
+                        f.write(chunk)
+                bpy.ops.import_scene.gltf(filepath=glb_path)
+                imported_objs = [obj for obj in bpy.context.selected_objects if obj.type == 'MESH']
+                if not imported_objs:
+                    return {"succeed": False, "error": "No mesh objects imported from GLB"}
+                obj = imported_objs[0]
+                if name:
+                    obj.name = name
+                result = {
+                    "name": obj.name, "type": obj.type,
+                    "location": [obj.location.x, obj.location.y, obj.location.z],
+                    "rotation": [obj.rotation_euler.x, obj.rotation_euler.y, obj.rotation_euler.z],
+                    "scale": [obj.scale.x, obj.scale.y, obj.scale.z],
+                }
+                if obj.type == "MESH":
+                    result["world_bounding_box"] = self._get_aabb(obj)
+                return {"succeed": True, **result}
+            except Exception as e:
+                return {"succeed": False, "error": str(e)}
+            finally:
+                with suppress(Exception):
+                    shutil.rmtree(temp_dir)
+
+        # Fallback: ZIP/OBJ import (legacy)
         temp_dir = tempfile.mkdtemp(prefix="tencent_obj_")
         zip_file_path = osp.join(temp_dir, "model.zip")
         obj_file_path = osp.join(temp_dir, "model.obj")
-        mtl_file_path = osp.join(temp_dir, "model.mtl")
-
         try:
-            # Download ZIP file
             zip_response = requests.get(zip_file_url, stream=True)
             zip_response.raise_for_status()
             with open(zip_file_path, "wb") as f:
                 for chunk in zip_response.iter_content(chunk_size=8192):
                     f.write(chunk)
-
-            # Unzip the ZIP
             with zipfile.ZipFile(zip_file_path, "r") as zip_ref:
+                # Mirror the Sketchfab zip-slip checks before extractall.
+                abs_temp_dir = os.path.abspath(temp_dir)
+                for file_info in zip_ref.infolist():
+                    file_path = file_info.filename
+                    target_path = os.path.join(temp_dir, os.path.normpath(file_path))
+                    abs_target_path = os.path.abspath(target_path)
+                    if not abs_target_path.startswith(abs_temp_dir + os.sep) and abs_target_path != abs_temp_dir:
+                        return {
+                            "succeed": False,
+                            "error": "Security issue: Zip contains files with path traversal attempt",
+                        }
+                    if ".." in file_path:
+                        return {
+                            "succeed": False,
+                            "error": "Security issue: Zip contains files with directory traversal sequence",
+                        }
                 zip_ref.extractall(temp_dir)
-
-            # Find the .obj file (there may be multiple, assuming the main file is model.obj)
             for file in os.listdir(temp_dir):
                 if file.endswith(".obj"):
                     obj_file_path = osp.join(temp_dir, file)
-
             if not osp.exists(obj_file_path):
                 return {"succeed": False, "error": "OBJ file not found after extraction"}
-
-            # Import obj file
             if bpy.app.version>=(4, 0, 0):
                 bpy.ops.wm.obj_import(filepath=obj_file_path)
             else:
                 bpy.ops.import_scene.obj(filepath=obj_file_path)
-
             imported_objs = [obj for obj in bpy.context.selected_objects if obj.type == 'MESH']
             if not imported_objs:
                 return {"succeed": False, "error": "No mesh objects imported"}
-
             obj = imported_objs[0]
             if name:
                 obj.name = name
-
             result = {
-                "name": obj.name,
-                "type": obj.type,
+                "name": obj.name, "type": obj.type,
                 "location": [obj.location.x, obj.location.y, obj.location.z],
                 "rotation": [obj.rotation_euler.x, obj.rotation_euler.y, obj.rotation_euler.z],
                 "scale": [obj.scale.x, obj.scale.y, obj.scale.z],
             }
-
             if obj.type == "MESH":
-                bounding_box = self._get_aabb(obj)
-                result["world_bounding_box"] = bounding_box
-
+                result["world_bounding_box"] = self._get_aabb(obj)
             return {"succeed": True, **result}
         except Exception as e:
             return {"succeed": False, "error": str(e)}
         finally:
-            #  Clean up temporary zip and obj, save texture and mtl
-            try:
-                if os.path.exists(zip_file_path):
-                    os.remove(zip_file_path) 
-                if os.path.exists(obj_file_path):
-                    os.remove(obj_file_path)
-            except Exception as e:
-                print(f"Failed to clean up temporary directory {temp_dir}: {e}")
+            with suppress(Exception):
+                shutil.rmtree(temp_dir)
     #endregion
 
 # Blender Addon Preferences

--- a/src/blender_mcp/server.py
+++ b/src/blender_mcp/server.py
@@ -1262,8 +1262,8 @@ def poll_hunyuan_job_status(
 
         Returns the generation task status. The task is done if status is "DONE".
         The task is in progress if status is "RUN".
-        If status is "DONE", returns ResultFile3Ds, which is the generated ZIP model path
-        When the status is "DONE", the response includes a field named ResultFile3Ds that contains the generated ZIP file path of the 3D model in OBJ format.
+        If status is "DONE", returns ResultFile3Ds with one or more downloadable model URLs.
+        Prefer a .glb URL when present (self-contained with materials); otherwise use a .zip/.obj asset URL.
         This is a polling API, so only proceed if the status are finally determined ("DONE" or some failed state).
     """
     try:
@@ -1289,7 +1289,7 @@ async def import_generated_asset_hunyuan(
 
     Parameters:
     - name: The name of the object in scene
-    - zip_file_url: The zip_file_url given in the generate model step.
+    - zip_file_url: A model URL from ResultFile3Ds. Prefer a .glb URL when available; .zip/.obj URLs still work as a fallback.
 
     Return if the asset has been imported successfully.
     """
@@ -1419,7 +1419,7 @@ def asset_creation_strategy() -> str:
                         2. Poll the status
                             - Use poll_hunyuan_job_status() to check if the generation task has completed or failed
                         3. Import the asset
-                            - Use import_generated_asset_hunyuan() to import the generated OBJ model the asset
+                            - Use import_generated_asset_hunyuan() with a ResultFile3Ds URL (prefer .glb, else .zip/.obj)
                     if Hunyuan3D mode is "LOCAL_API":
                         - For objects/models, do the following steps:
                         1. Create the model generation task

--- a/test_hunyuan_import_security.py
+++ b/test_hunyuan_import_security.py
@@ -1,0 +1,151 @@
+"""Regression coverage for Hunyuan import URL routing and zip-slip checks."""
+import importlib.util
+import io
+import pathlib
+import sys
+import types
+import zipfile
+
+ADDON = pathlib.Path(__file__).with_name("addon.py")
+
+
+def _install_bpy_stubs(monkeypatch, scene):
+    bpy = types.ModuleType("bpy")
+    bpy.context = types.SimpleNamespace(scene=scene, selected_objects=[])
+    bpy.types = types.SimpleNamespace(
+        AddonPreferences=object,
+        Operator=object,
+        Panel=object,
+        Scene=type("Scene", (), {}),
+    )
+    bpy.ops = types.SimpleNamespace(
+        import_scene=types.SimpleNamespace(
+            gltf=lambda **_kwargs: (_ for _ in ()).throw(AssertionError("unexpected gltf import")),
+            obj=lambda **_kwargs: (_ for _ in ()).throw(AssertionError("unexpected obj import")),
+        ),
+        wm=types.SimpleNamespace(
+            obj_import=lambda **_kwargs: (_ for _ in ()).throw(AssertionError("unexpected obj import")),
+        ),
+    )
+
+    props = types.ModuleType("bpy.props")
+    for name in ("BoolProperty", "EnumProperty", "FloatProperty", "IntProperty", "StringProperty"):
+        setattr(props, name, lambda **_kwargs: None)
+    bpy.props = props
+
+    handlers = types.ModuleType("bpy.app.handlers")
+    handlers.persistent = lambda fn: fn
+    handlers.undo_post = []
+    handlers.redo_post = []
+    handlers.depsgraph_update_post = []
+
+    app = types.ModuleType("bpy.app")
+    app.version = (4, 2, 0)
+    app.version_string = "4.2.0"
+    app.background = False
+    app.handlers = handlers
+    app.timers = types.SimpleNamespace(
+        is_registered=lambda *_a, **_k: False,
+        register=lambda *_a, **_k: None,
+        unregister=lambda *_a, **_k: None,
+    )
+    bpy.app = app
+
+    monkeypatch.setitem(sys.modules, "bpy", bpy)
+    monkeypatch.setitem(sys.modules, "bpy.props", props)
+    monkeypatch.setitem(sys.modules, "bpy.app", app)
+    monkeypatch.setitem(sys.modules, "bpy.app.handlers", handlers)
+    monkeypatch.setitem(sys.modules, "mathutils", types.ModuleType("mathutils"))
+
+    requests = types.ModuleType("requests")
+    requests.utils = types.SimpleNamespace(default_headers=dict)
+    requests.exceptions = types.SimpleNamespace(Timeout=TimeoutError)
+    monkeypatch.setitem(sys.modules, "requests", requests)
+    return bpy
+
+
+def _load_addon(monkeypatch):
+    scene = types.SimpleNamespace(
+        blendermcp_use_polyhaven=False,
+        blendermcp_use_hyper3d=False,
+        blendermcp_use_hunyuan3d=True,
+        blendermcp_use_sketchfab=False,
+    )
+    bpy = _install_bpy_stubs(monkeypatch, scene)
+    spec = importlib.util.spec_from_file_location("blender_mcp_addon_hunyuan_test", ADDON)
+    addon = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(addon)
+    return addon, bpy
+
+
+class _FakeResponse:
+    def __init__(self, content: bytes):
+        self.content = content
+        self.status_code = 200
+
+    def raise_for_status(self):
+        return None
+
+    def iter_content(self, chunk_size=8192):
+        yield self.content
+
+
+def test_hunyuan_import_prefers_glb_urls(monkeypatch):
+    addon, bpy = _load_addon(monkeypatch)
+    server = addon.BlenderMCPServer()
+    called = {"gltf": False}
+
+    def gltf_import(**_kwargs):
+        called["gltf"] = True
+        mesh = types.SimpleNamespace(
+            type="MESH",
+            name="Imported",
+            location=types.SimpleNamespace(x=0, y=0, z=0),
+            rotation_euler=types.SimpleNamespace(x=0, y=0, z=0),
+            scale=types.SimpleNamespace(x=1, y=1, z=1),
+        )
+        bpy.context.selected_objects = [mesh]
+
+    bpy.ops.import_scene.gltf = gltf_import
+    monkeypatch.setattr(
+        addon.requests,
+        "get",
+        lambda *_args, **_kwargs: _FakeResponse(b"glb-bytes"),
+        raising=False,
+    )
+    monkeypatch.setattr(server, "_get_aabb", lambda _obj: [0, 0, 0, 1, 1, 1])
+
+    result = server.import_generated_asset_hunyuan_ai(
+        "Chair",
+        "https://example.com/models/asset.GLB?sign=abc",
+    )
+
+    assert called["gltf"] is True
+    assert result["succeed"] is True
+    assert result["name"] == "Chair"
+
+
+def test_hunyuan_zip_rejects_path_traversal(monkeypatch):
+    addon, _bpy = _load_addon(monkeypatch)
+    server = addon.BlenderMCPServer()
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("../evil.txt", "nope")
+        zf.writestr("model.obj", "o test\n")
+    payload = buf.getvalue()
+
+    monkeypatch.setattr(
+        addon.requests,
+        "get",
+        lambda *_args, **_kwargs: _FakeResponse(payload),
+        raising=False,
+    )
+
+    result = server.import_generated_asset_hunyuan_ai(
+        "BadZip",
+        "https://example.com/models/asset.zip",
+    )
+
+    assert result["succeed"] is False
+    assert "path traversal" in result["error"].lower() or "directory traversal" in result["error"].lower()

--- a/test_sketchfab_status.py
+++ b/test_sketchfab_status.py
@@ -22,8 +22,28 @@ def _load_addon(monkeypatch, scene):
         setattr(props, name, lambda **_kwargs: None)
     bpy.props = props
 
+    handlers = types.ModuleType("bpy.app.handlers")
+    handlers.persistent = lambda fn: fn
+    handlers.undo_post = []
+    handlers.redo_post = []
+    handlers.depsgraph_update_post = []
+
+    app = types.ModuleType("bpy.app")
+    app.version = (4, 2, 0)
+    app.version_string = "4.2.0"
+    app.background = False
+    app.handlers = handlers
+    app.timers = types.SimpleNamespace(
+        is_registered=lambda *_a, **_k: False,
+        register=lambda *_a, **_k: None,
+        unregister=lambda *_a, **_k: None,
+    )
+    bpy.app = app
+
     monkeypatch.setitem(sys.modules, "bpy", bpy)
     monkeypatch.setitem(sys.modules, "bpy.props", props)
+    monkeypatch.setitem(sys.modules, "bpy.app", app)
+    monkeypatch.setitem(sys.modules, "bpy.app.handlers", handlers)
     monkeypatch.setitem(sys.modules, "mathutils", types.ModuleType("mathutils"))
 
     requests = types.ModuleType("requests")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Follow-up to #294 so `install-addon` users actually get the AI3D migration.

Rebased onto current `main` after the history rewrite — conflicts are resolved.

- Sync `src/blender_mcp/bundled/addon.py` with root `addon.py` (AI3D API + Sketchfab status fix + GLB import + zip-slip guard)
- Add Sketchfab-style zip-slip checks to the Hunyuan ZIP/OBJ fallback
- Prefer `.glb` ResultFile3Ds URLs in `server.py` tool/strategy docs
- Bump package version to `1.8.3` for the next PyPI publish
- Add regression tests for GLB URL routing and zip-slip rejection; fix Sketchfab test stubs for `bpy.app.handlers`

## Test plan
- [x] `python -m pytest -q` (4 passed)
- [x] Confirm `cmp addon.py src/blender_mcp/bundled/addon.py`
- [x] After merge: publish `1.8.3` to PyPI and re-run `uvx blender-mcp install-addon`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sids-agents.slack.com/archives/C0BHZ444DM5/p1786886961350089?thread_ts=1786886961.350089&cid=C0BHZ444DM5)

<div><a href="https://cursor.com/agents/bc-9da83c4b-1304-51a8-8d2b-afa1903ed21e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9da83c4b-1304-51a8-8d2b-afa1903ed21e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

