### PR TITLE
Make telemetry consent opt-in (shared global switch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,13 +494,18 @@ The system uses a simple JSON-based protocol over TCP sockets:
 
 ## Telemetry Control
 
-BlenderMCP collects anonymous usage data to help improve the tool. Telemetry consent is **on by default**, and you can turn it off in two ways:
+BlenderMCP can collect anonymous usage data to help improve the tool. Telemetry is **off by default** (opt-in). Everything below writes the same global `telemetry_consent` switch:
 
-**1. In Blender** — go to **Edit → Preferences → Add-ons → Blender MCP** and uncheck the telemetry consent checkbox.
+**1. In Blender (easiest)** — in the **BlenderMCP** sidebar (N-panel), tick **Allow Telemetry (opt-in)**. The same checkbox is also under **Edit → Preferences → Add-ons → Blender MCP**.
 
-- With consent (checked, the default): view the TnC for more details on data collected.
+**2. From chat** — ask the assistant to turn collection on or off (`enable_telemetry` / `disable_telemetry`).
 
-**2. Environment Variable** — completely disable all telemetry by running:
+**3. First-run prompt** — MCP clients that support elicitation may ask once; Yes writes the same switch.
+
+- With consent (checked): view the TnC for more details on data collected.
+- Without consent (default): only minimal anonymous usage counts (tool name, success/failure, duration).
+
+**Hard disable** — completely disable all telemetry (including minimal counts) by running:
 
 ```bash
 DISABLE_TELEMETRY=true uvx blender-mcp
@@ -524,7 +529,7 @@ Or add it to your MCP config:
 
 Telemetry data is not linked to your name or account. It may be used to improve BlenderMCP, for research, and to train AI models.
 
-Full detail on what is collected, and the license you grant by leaving telemetry on, is in [TERMS_AND_CONDITIONS.md](TERMS_AND_CONDITIONS.md).
+Full detail on what is collected, and the license you grant by opting in, is in [TERMS_AND_CONDITIONS.md](TERMS_AND_CONDITIONS.md).
 
 ---
 

--- a/TERMS_AND_CONDITIONS.md
+++ b/TERMS_AND_CONDITIONS.md
@@ -33,7 +33,7 @@ I do **not** collect:
 - Passwords or financial information
 - Data from other applications on your system
 
-Trajectory, screenshot, and manual-edit collection only occurs while telemetry consent is enabled in the Blender MCP addon preferences — it is enabled by default, and you can turn it off there at any time — **and** the MCP server is running. Turning off consent or stopping the server removes the handlers that observe your manual edits.
+Trajectory, screenshot, and manual-edit collection only occurs while telemetry consent is enabled in the Blender MCP addon — it is **off by default** (opt-in); you can turn it on via the BlenderMCP sidebar checkbox, Preferences → Add-ons → Blender MCP, the first-run prompt, or the `enable_telemetry` tool — **and** the MCP server is running. Turning off consent or stopping the server removes the handlers that observe your manual edits.
 
 Without consent, a minimal anonymous usage record is still sent so I can count active users: a randomly generated install ID, a session ID, the tool name, whether it succeeded, how long it took, the Blender MCP and Blender versions, your operating system, and a timestamp. No prompts, code, screenshots, scene data, or manual-edit records are included.
 
@@ -74,7 +74,7 @@ You may:
 
 - **Request access** to the data I've collected from your usage
 - **Request deletion** of your data
-- **Opt out of telemetry** by unchecking the telemetry option in the Blender MCP addon preferences. When disabled, no data is collected, and you can continue using the software normally.
+- **Opt in or out of telemetry** using the BlenderMCP sidebar checkbox, Preferences → Add-ons → Blender MCP, or the `enable_telemetry` / `disable_telemetry` tools. When disabled (the default), rich session data is not collected, and you can continue using the software normally. Minimal anonymous usage counts may still apply unless `DISABLE_TELEMETRY` is set.
 
 To exercise these rights, contact me at ahujasid@gmail.com.
 
@@ -179,7 +179,7 @@ By using Blender MCP with telemetry enabled, you acknowledge that:
 4. You understand this data may be used to train AI models or released as part of open datasets
 5. You understand that once data is used for training or released publicly, it cannot be fully deleted
 6. You are at least 16 years old
-7. You can disable telemetry at any time in the addon preferences
+7. You can enable or disable telemetry at any time via the addon sidebar/preferences or the enable/disable telemetry tools
 
 ---
 

--- a/addon.py
+++ b/addon.py
@@ -1877,10 +1877,10 @@ class BlenderMCPServer:
     def set_telemetry_consent(self, consent=False):
         """Write the telemetry consent preference.
 
-        Only reached when the user answered an elicitation prompt in their MCP
-        client, or asked to opt out. Assigning the property in code skips the
-        BoolProperty update= callback, so the manual-edit handlers are
-        re-synced explicitly.
+        Single global switch shared by the BlenderMCP sidebar checkbox,
+        Preferences, first-run elicitation, and enable/disable_telemetry MCP
+        tools. Assigning the property in code skips the BoolProperty update=
+        callback, so the manual-edit handlers are re-synced explicitly.
         """
         try:
             addon_prefs = bpy.context.preferences.addons.get(__name__)
@@ -3153,8 +3153,8 @@ class BLENDERMCP_AddonPreferences(bpy.types.AddonPreferences):
 
     telemetry_consent: BoolProperty(
         name="Allow Telemetry",
-        description="Allow collection of prompts, code snippets, screenshots, and trajectory data to help improve Blender MCP",
-        default=True,
+        description="Opt in to collection of prompts, code snippets, screenshots, and trajectory data to help improve Blender MCP. Off by default.",
+        default=False,
         update=_on_telemetry_consent_changed,
     )
     hyper3d_api_key: bpy.props.StringProperty(
@@ -3189,20 +3189,20 @@ class BLENDERMCP_AddonPreferences(bpy.types.AddonPreferences):
     def draw(self, context):
         layout = self.layout
         
-        # Telemetry section
+        # Telemetry section (same switch as the sidebar panel and MCP tools)
         layout.label(text="Telemetry & Privacy:", icon='PREFERENCES')
         
         box = layout.box()
         row = box.row()
-        row.prop(self, "telemetry_consent", text="Allow Telemetry")
+        row.prop(self, "telemetry_consent", text="Allow Telemetry (opt-in)")
 
         # Info text
         box.separator()
         if self.telemetry_consent:
-            box.label(text="With consent: We collect anonymized prompts, code, screenshots,", icon='INFO')
+            box.label(text="Opted in: We collect anonymized prompts, code, screenshots,", icon='INFO')
             box.label(text="and trajectory data (actions, scene state, feedback).", icon='BLANK1')
         else:
-            box.label(text="Without consent: We only collect minimal anonymous usage data", icon='INFO')
+            box.label(text="Opted out (default): Only minimal anonymous usage data", icon='INFO')
             box.label(text="(tool names, success/failure, duration - no prompts or code).", icon='BLANK1')
         box.separator()
         box.label(text="Data is not linked to your name or account. Change this anytime.", icon='CHECKMARK')
@@ -3278,6 +3278,20 @@ class BLENDERMCP_PT_Panel(bpy.types.Panel):
         else:
             layout.operator("blendermcp.stop_server", text="Disconnect from MCP server")
             layout.label(text=f"Running on port {scene.blendermcp_port}")
+
+        # Same global switch as Preferences and enable/disable_telemetry MCP tools
+        layout.separator()
+        telemetry_box = layout.box()
+        telemetry_box.label(text="Help improve Blender MCP", icon='INFO')
+        if prefs:
+            telemetry_box.prop(prefs, "telemetry_consent", text="Allow Telemetry (opt-in)")
+            if prefs.telemetry_consent:
+                telemetry_box.label(text="Sharing prompts, code, screenshots & scene data")
+            else:
+                telemetry_box.label(text="Off by default — tick to opt in")
+            telemetry_box.operator("blendermcp.open_terms", text="Terms & Conditions", icon='TEXT')
+        else:
+            telemetry_box.label(text="Open Preferences → Add-ons → Blender MCP")
         
         # Feedback section
         layout.separator()

--- a/src/blender_mcp/bundled/addon.py
+++ b/src/blender_mcp/bundled/addon.py
@@ -1877,10 +1877,10 @@ class BlenderMCPServer:
     def set_telemetry_consent(self, consent=False):
         """Write the telemetry consent preference.
 
-        Only reached when the user answered an elicitation prompt in their MCP
-        client, or asked to opt out. Assigning the property in code skips the
-        BoolProperty update= callback, so the manual-edit handlers are
-        re-synced explicitly.
+        Single global switch shared by the BlenderMCP sidebar checkbox,
+        Preferences, first-run elicitation, and enable/disable_telemetry MCP
+        tools. Assigning the property in code skips the BoolProperty update=
+        callback, so the manual-edit handlers are re-synced explicitly.
         """
         try:
             addon_prefs = bpy.context.preferences.addons.get(__name__)
@@ -3153,8 +3153,8 @@ class BLENDERMCP_AddonPreferences(bpy.types.AddonPreferences):
 
     telemetry_consent: BoolProperty(
         name="Allow Telemetry",
-        description="Allow collection of prompts, code snippets, screenshots, and trajectory data to help improve Blender MCP",
-        default=True,
+        description="Opt in to collection of prompts, code snippets, screenshots, and trajectory data to help improve Blender MCP. Off by default.",
+        default=False,
         update=_on_telemetry_consent_changed,
     )
     hyper3d_api_key: bpy.props.StringProperty(
@@ -3189,20 +3189,20 @@ class BLENDERMCP_AddonPreferences(bpy.types.AddonPreferences):
     def draw(self, context):
         layout = self.layout
         
-        # Telemetry section
+        # Telemetry section (same switch as the sidebar panel and MCP tools)
         layout.label(text="Telemetry & Privacy:", icon='PREFERENCES')
         
         box = layout.box()
         row = box.row()
-        row.prop(self, "telemetry_consent", text="Allow Telemetry")
+        row.prop(self, "telemetry_consent", text="Allow Telemetry (opt-in)")
 
         # Info text
         box.separator()
         if self.telemetry_consent:
-            box.label(text="With consent: We collect anonymized prompts, code, screenshots,", icon='INFO')
+            box.label(text="Opted in: We collect anonymized prompts, code, screenshots,", icon='INFO')
             box.label(text="and trajectory data (actions, scene state, feedback).", icon='BLANK1')
         else:
-            box.label(text="Without consent: We only collect minimal anonymous usage data", icon='INFO')
+            box.label(text="Opted out (default): Only minimal anonymous usage data", icon='INFO')
             box.label(text="(tool names, success/failure, duration - no prompts or code).", icon='BLANK1')
         box.separator()
         box.label(text="Data is not linked to your name or account. Change this anytime.", icon='CHECKMARK')
@@ -3278,6 +3278,20 @@ class BLENDERMCP_PT_Panel(bpy.types.Panel):
         else:
             layout.operator("blendermcp.stop_server", text="Disconnect from MCP server")
             layout.label(text=f"Running on port {scene.blendermcp_port}")
+
+        # Same global switch as Preferences and enable/disable_telemetry MCP tools
+        layout.separator()
+        telemetry_box = layout.box()
+        telemetry_box.label(text="Help improve Blender MCP", icon='INFO')
+        if prefs:
+            telemetry_box.prop(prefs, "telemetry_consent", text="Allow Telemetry (opt-in)")
+            if prefs.telemetry_consent:
+                telemetry_box.label(text="Sharing prompts, code, screenshots & scene data")
+            else:
+                telemetry_box.label(text="Off by default — tick to opt in")
+            telemetry_box.operator("blendermcp.open_terms", text="Terms & Conditions", icon='TEXT')
+        else:
+            telemetry_box.label(text="Open Preferences → Add-ons → Blender MCP")
         
         # Feedback section
         layout.separator()

--- a/src/blender_mcp/consent_prompt.py
+++ b/src/blender_mcp/consent_prompt.py
@@ -1,13 +1,13 @@
 """First-run telemetry consent prompt.
 
 Consent lives in one place: the ``telemetry_consent`` checkbox in the Blender
-addon preferences, which is on by default. This module only decides *when* to
-ask about it and how the answer gets there, so it only has anything to do for
-users who have turned the checkbox off.
+addon preferences (also shown on the BlenderMCP sidebar). It is **off by
+default** (opt-in). This module decides *when* to ask and how the answer gets
+written to that same switch.
 
 Only clients declaring the ``elicitation`` capability are asked, via a yes/no
 dialog the client renders itself; only an explicit ``accept`` with
-``consent=True`` turns collection back on. Clients without it are left alone --
+``consent=True`` turns collection on. Clients without it are left alone --
 a model relaying a prose answer is not the user answering, so those users are
 asked in the Blender addon instead.
 
@@ -29,7 +29,7 @@ from pydantic import BaseModel, Field
 logger = logging.getLogger("BlenderMCPConsent")
 
 # Bump to re-ask everyone (e.g. if what gets collected changes materially).
-CONSENT_PROMPT_VERSION = 1
+CONSENT_PROMPT_VERSION = 2
 
 _state_lock = threading.Lock()
 # Keyed by client session: the server process outlives any one conversation.
@@ -51,9 +51,10 @@ class TelemetryConsentResponse(BaseModel):
 PROMPT_MESSAGE = (
     "Blender MCP can collect data from this session to help improve the tool: "
     "your prompts, the code that gets generated, viewport screenshots, and scene "
-    "metadata. It is not linked to your name or account, and you can change this "
-    "any time in Blender under Preferences > Add-ons > Blender MCP.\n\n"
-    "Collection is on by default, but it is currently OFF for you. Turn it back on?"
+    "metadata. It is not linked to your name or account. Collection is off unless "
+    "you opt in, and you can change this any time in Blender (sidebar checkbox or "
+    "Preferences > Add-ons > Blender MCP).\n\n"
+    "Help improve Blender MCP by turning collection on?"
 )
 
 def _state_path() -> Path:
@@ -136,7 +137,7 @@ def _apply_consent(consent: bool) -> bool:
     """Write consent to Blender and refresh the cached value."""
     try:
         from .server import get_blender_connection
-        from .telemetry import telemetry
+        from .telemetry import get_telemetry
 
         blender = get_blender_connection()
         result = blender.send_command(
@@ -145,7 +146,7 @@ def _apply_consent(consent: bool) -> bool:
         if "error" in result:
             logger.debug(f"Addon rejected consent write: {result['error']}")
             return False
-        telemetry.invalidate_consent_cache()
+        get_telemetry().invalidate_consent_cache()
         return True
     except Exception as e:
         logger.debug(f"Could not set telemetry consent: {e}")
@@ -195,8 +196,9 @@ async def maybe_prompt_for_consent(ctx: Any) -> str:
             if granted and _apply_consent(True):
                 return (
                     "\n\n---\n"
-                    "Data collection is now ON. You can turn it off any time in "
-                    "Blender under Preferences > Add-ons > Blender MCP."
+                    "Data collection is now ON. You can turn it off any time via "
+                    "the BlenderMCP sidebar, Preferences > Add-ons > Blender MCP, "
+                    "or the disable_telemetry tool."
                 )
             return ""
 

--- a/src/blender_mcp/server.py
+++ b/src/blender_mcp/server.py
@@ -338,15 +338,40 @@ async def get_addon_status(ctx: Context, user_prompt: str = "") -> str:
 
 
 @mcp.tool()
+def enable_telemetry(ctx: Context, user_prompt: str = "") -> str:
+    """
+    Turn ON collection of prompts, code, screenshots and scene data (opt-in).
+
+    Use this when the user clearly wants to help improve Blender MCP, opt in to
+    telemetry, or start sharing session data. Writes the same global
+    `telemetry_consent` switch as the Blender sidebar checkbox and Preferences.
+    Takes effect immediately.
+    """
+    try:
+        blender = get_blender_connection()
+        result = blender.send_command("set_telemetry_consent", {"consent": True})
+        if "error" in result:
+            return f"Could not turn on data collection: {result['error']}"
+        get_telemetry().invalidate_consent_cache()
+        return (
+            "Data collection is now ON. Prompts, code, screenshots and scene "
+            "data may be collected to improve Blender MCP (not linked to your "
+            "name or account). Turn it off any time with disable_telemetry, or "
+            "untick 'Allow Telemetry' in the BlenderMCP sidebar / Preferences."
+        )
+    except Exception as e:
+        return f"Error turning on data collection: {e}"
+
+
+@mcp.tool()
 def disable_telemetry(ctx: Context, user_prompt: str = "") -> str:
     """
     Turn OFF collection of prompts, code, screenshots and scene data.
 
     Use this whenever the user asks to stop data collection, opt out of
-    telemetry, or stop sharing their data. Takes effect immediately.
-
-    This tool can only turn collection OFF. Turning it back on is done by the
-    user in Blender under Preferences > Add-ons > Blender MCP.
+    telemetry, or stop sharing their data. Writes the same global
+    `telemetry_consent` switch as the Blender sidebar checkbox and Preferences.
+    Takes effect immediately.
     """
     try:
         blender = get_blender_connection()
@@ -358,8 +383,8 @@ def disable_telemetry(ctx: Context, user_prompt: str = "") -> str:
             "Data collection is now OFF. Prompts, code, screenshots and scene "
             "data are no longer collected. Minimal anonymous usage counts "
             "(tool name, success, duration) still apply -- see the terms for "
-            "details. To turn collection back on, tick 'Allow Telemetry' in "
-            "Blender under Preferences > Add-ons > Blender MCP."
+            "details. To opt in again, use enable_telemetry or tick "
+            "'Allow Telemetry' in the BlenderMCP sidebar / Preferences."
         )
     except Exception as e:
         return f"Error turning off data collection: {e}"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Telemetry is now **opt-in** instead of opt-out. All surfaces write the same `telemetry_consent` preference:

- **Default off** in addon Preferences (`Allow Telemetry`)
- **Same checkbox** on the BlenderMCP sidebar near Connect
- **First-run elicitation** asks once (opt-in wording; prompt version bumped)
- **`enable_telemetry` / `disable_telemetry`** MCP tools toggle the same switch
- Docs (README + Terms) updated for opt-in

`DISABLE_TELEMETRY` env hard-kill is unchanged.

## Note on existing installs
Blender persists addon preferences. Flipping `default=False` applies to new installs; users who already have a saved value keep it. Fresh installs and anyone who never saved prefs get opt-in (off).

## Test plan
- [x] `pytest tests/` — 20 passed
- [ ] Fresh addon: checkbox off by default in Preferences and sidebar
- [ ] Tick sidebar checkbox → `get_addon_status` reports `telemetry_consent: true`
- [ ] `enable_telemetry` / `disable_telemetry` flip the same checkbox
- [ ] Clients with elicitation see the first-run opt-in prompt when consent is off

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sids-agents.slack.com/archives/C0BHZ444DM5/p1786903220898239?thread_ts=1786903220.898239&cid=C0BHZ444DM5)

<div><a href="https://cursor.com/agents/bc-6d8056b0-f4ee-57a6-8ff5-a8ce6f33038e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d8056b0-f4ee-57a6-8ff5-a8ce6f33038e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

