### PR TITLE
fix(addon): handle split multi-byte UTF-8 sequences in socket buffer

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -576,8 +576,11 @@ class BlenderMCPServer:
                         # thread-safe and the callback can be silently lost.
                         print(f"Queued command: {command.get('type')}")
                         self.command_queue.put((command, client))
-                    except json.JSONDecodeError:
-                        # Incomplete data, wait for more
+                    except (json.JSONDecodeError, UnicodeDecodeError):
+                        # Incomplete data, wait for more. A multi-byte UTF-8
+                        # character can land split across a recv() chunk
+                        # boundary, which fails decode() before json.loads()
+                        # ever runs - that's incomplete data too, not garbage.
                         pass
                 except socket.timeout:
                     # Expected; loop round and re-check self.running.

--- a/src/blender_mcp/bundled/addon.py
+++ b/src/blender_mcp/bundled/addon.py
@@ -576,8 +576,11 @@ class BlenderMCPServer:
                         # thread-safe and the callback can be silently lost.
                         print(f"Queued command: {command.get('type')}")
                         self.command_queue.put((command, client))
-                    except json.JSONDecodeError:
-                        # Incomplete data, wait for more
+                    except (json.JSONDecodeError, UnicodeDecodeError):
+                        # Incomplete data, wait for more. A multi-byte UTF-8
+                        # character can land split across a recv() chunk
+                        # boundary, which fails decode() before json.loads()
+                        # ever runs - that's incomplete data too, not garbage.
                         pass
                 except socket.timeout:
                     # Expected; loop round and re-check self.running.

--- a/tests/test_socket_unicode.py
+++ b/tests/test_socket_unicode.py
@@ -1,0 +1,116 @@
+"""Regression coverage for split multi-byte UTF-8 sequences in the socket buffer.
+
+The bug: `_handle_client` accumulates `recv()` chunks into `buffer` and does
+`buffer.decode('utf-8')` before attempting `json.loads()`. Only
+`json.JSONDecodeError` was caught, treated as "incomplete data, wait for more".
+If a multi-byte UTF-8 character (e.g. an accented letter, CJK text, or an
+emoji in an object name or in LLM-generated code) is split across a `recv()`
+chunk boundary, `.decode('utf-8')` raises `UnicodeDecodeError` instead -
+uncaught here, so it falls through to the outer `except Exception`, which
+logs and `break`s. The command is dropped and the connection is torn down,
+even though the rest of the payload was already sitting in the OS receive
+buffer waiting to be read.
+
+A real loopback socket won't reliably reproduce an exact byte-offset split
+(the OS may coalesce separate `sendall()` calls into one `recv()`), so this
+drives `_handle_client` directly with a fake socket that returns pre-scripted
+chunks - deterministic, no network, no flakiness.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from test_server_threading import BlenderMCPServer
+
+
+class _ScriptedSocket:
+    """Fake client socket returning pre-scripted recv() chunks, one per call."""
+
+    def __init__(self, chunks):
+        self._chunks = list(chunks)
+        self.sent = []
+
+    def settimeout(self, timeout):
+        pass
+
+    def recv(self, bufsize):
+        if self._chunks:
+            return self._chunks.pop(0)
+        return b""
+
+    def sendall(self, data):
+        self.sent.append(data)
+
+    def close(self):
+        pass
+
+
+def _make_server():
+    server = BlenderMCPServer(port=0)
+    server.execute_command = lambda command: {"status": "success", "result": {}}
+    return server
+
+
+def _split_after_lead_byte(payload: bytes) -> int:
+    """Index right after a multi-byte UTF-8 lead byte's first byte.
+
+    Splitting there guarantees the first chunk ends mid-character, so
+    decoding it alone as UTF-8 raises UnicodeDecodeError.
+    """
+    for i, b in enumerate(payload):
+        if b >= 0xC0:  # lead byte of a 2/3/4-byte sequence
+            return i + 1
+    raise AssertionError("payload has no multi-byte UTF-8 character to split")
+
+
+def test_split_multibyte_utf8_boundary_is_not_dropped():
+    payload = json.dumps(
+        {"type": "ping", "params": {"note": "café ☕ 日本語"}}, ensure_ascii=False
+    ).encode("utf-8")
+    split_idx = _split_after_lead_byte(payload)
+    chunk1, chunk2 = payload[:split_idx], payload[split_idx:]
+
+    # Sanity check: confirm the split really does land mid-character, i.e.
+    # this fixture actually exercises the bug and isn't accidentally valid.
+    with pytest.raises(UnicodeDecodeError):
+        chunk1.decode("utf-8")
+
+    server = _make_server()
+    server.running = True
+    server._handle_client(_ScriptedSocket([chunk1, chunk2]))
+
+    assert not server.command_queue.empty(), (
+        "command was dropped: a multi-byte UTF-8 character split across a "
+        "recv() chunk boundary killed the connection instead of waiting for "
+        "the rest of the buffer"
+    )
+    command, _client = server.command_queue.get_nowait()
+    assert command["type"] == "ping"
+    assert command["params"]["note"] == "café ☕ 日本語"
+
+
+def test_split_multibyte_utf8_boundary_keeps_handler_loop_alive():
+    """A second command sent right after the split payload must still arrive.
+
+    If the split killed the loop, this second command would never be queued.
+    """
+    first = json.dumps(
+        {"type": "ping", "params": {"note": "emoji test 🎨"}}, ensure_ascii=False
+    ).encode("utf-8")
+    split_idx = _split_after_lead_byte(first)
+    second = json.dumps({"type": "ping", "params": {}}).encode("utf-8")
+
+    server = _make_server()
+    server.running = True
+    server._handle_client(
+        _ScriptedSocket([first[:split_idx], first[split_idx:], second])
+    )
+
+    queued = []
+    while not server.command_queue.empty():
+        command, _client = server.command_queue.get_nowait()
+        queued.append(command)
+
+    assert len(queued) == 2, f"expected both commands queued, got {queued}"


### PR DESCRIPTION
## Root Cause

`_handle_client` accumulates `recv()` chunks into `buffer` and does `buffer.decode('utf-8')` before attempting `json.loads()`:

```python
buffer += data
try:
    command = json.loads(buffer.decode('utf-8'))
    buffer = b''
    ...
except json.JSONDecodeError:
    # Incomplete data, wait for more
    pass
```

Only `json.JSONDecodeError` is caught and treated as "incomplete data, wait for more." If a multi-byte UTF-8 character — an accented letter, CJK text, or an emoji inside an object name, a scene string, or LLM-generated code passed to `execute_code` — lands split across a `recv(8192)` chunk boundary, `.decode('utf-8')` raises `UnicodeDecodeError` *before* `json.loads()` ever runs. That exception is not caught here, so it falls through to the outer handler:

```python
except Exception as e:
    print(f"Error receiving data: {str(e)}")
    break
```

...which drops the command and tears down the connection, even though the rest of the payload was already sitting in the OS receive buffer waiting to be read on the next `recv()` call.

## Fix

Catch `UnicodeDecodeError` alongside `json.JSONDecodeError` in the same place — a split multi-byte character is "incomplete data," not garbage, so the buffer should simply wait for the next chunk instead of killing the connection. Applied identically to both `addon.py` and `src/blender_mcp/bundled/addon.py` (kept in sync, per `test_addon_manager.py::test_root_and_bundled_addon_in_sync`).

## Test Coverage

Added `tests/test_socket_unicode.py`, following the pattern in `tests/test_server_threading.py` (reuses its AST-lifted `BlenderMCPServer` against stubs, no real Blender or network needed):

- `test_split_multibyte_utf8_boundary_is_not_dropped` — drives `_handle_client` with a fake socket scripted to return a JSON payload's UTF-8 bytes split exactly mid-character (via a deterministic `recv()` stub, since a real loopback socket won't reliably reproduce an exact byte-offset split — the OS may coalesce writes). Confirmed this reproduces the bug on unpatched code: the command is silently dropped and the handler loop exits after only the first chunk.
- `test_split_multibyte_utf8_boundary_keeps_handler_loop_alive` — confirms a second command sent right after the split payload still arrives, i.e. the connection isn't torn down.

Both fail on `main` today and pass with this fix. Full suite (`pytest`, 22 tests) passes; `ruff check` / `ruff format --check` report no new issues on the touched files (the repo's existing lint/format debt on `addon.py` is pre-existing and tracked separately by #284).