### PR TITLE
fix: auto-start on the configured port and sync the panel flag

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -251,6 +251,38 @@ def _blendermcp_depsgraph_post(scene, depsgraph=None):
     _edit_recorder.poll_operators()
 
 
+# Set when the user clicks Disconnect, so that opening a .blend afterwards does
+# not silently bring the server back up behind them. An explicit Connect clears
+# it, as does restarting Blender (the addon re-registers).
+_user_stopped_server = False
+
+
+@persistent
+def _blendermcp_on_load_post(*args):
+    """Start the server against the loaded scene and re-sync the panel flag.
+
+    register() runs before Blender has read a .blend, so bpy.context.scene is
+    None at startup: the file's port cannot be read and blendermcp_server_running
+    cannot be written. load_post is the first point where the scene exists.
+    """
+    scene = getattr(bpy.context, "scene", None)
+    if scene is None:
+        return
+
+    server = getattr(bpy.types, "blendermcp_server", None)
+    if scene.blendermcp_auto_start_server and not _user_stopped_server:
+        if server is None:
+            server = BlenderMCPServer(port=scene.blendermcp_port)
+            bpy.types.blendermcp_server = server
+        if not server.running:
+            # Only safe to retarget while stopped; a running server keeps its
+            # port so an already-connected client is not dropped.
+            server.port = scene.blendermcp_port
+            server.start()
+
+    scene.blendermcp_server_running = bool(server is not None and server.running)
+
+
 def _telemetry_consent_enabled():
     """Read the consent preference directly. Fails closed."""
     try:
@@ -3277,7 +3309,9 @@ class BLENDERMCP_PT_Panel(bpy.types.Panel):
             layout.operator("blendermcp.start_server", text="Connect to MCP server")
         else:
             layout.operator("blendermcp.stop_server", text="Disconnect from MCP server")
-            layout.label(text=f"Running on port {scene.blendermcp_port}")
+            server = getattr(bpy.types, "blendermcp_server", None)
+            running_port = getattr(server, "port", scene.blendermcp_port)
+            layout.label(text=f"Running on port {running_port}")
         
         # Feedback section
         layout.separator()
@@ -3318,7 +3352,9 @@ class BLENDERMCP_OT_StartServer(bpy.types.Operator):
     bl_description = "Start the BlenderMCP server to connect with Claude"
 
     def execute(self, context):
+        global _user_stopped_server
         scene = context.scene
+        _user_stopped_server = False
 
         # Create a new server instance
         if not hasattr(bpy.types, "blendermcp_server") or not bpy.types.blendermcp_server:
@@ -3337,7 +3373,9 @@ class BLENDERMCP_OT_StopServer(bpy.types.Operator):
     bl_description = "Stop the connection to Claude"
 
     def execute(self, context):
+        global _user_stopped_server
         scene = context.scene
+        _user_stopped_server = True
 
         # Stop the server if it exists
         if hasattr(bpy.types, "blendermcp_server") and bpy.types.blendermcp_server:
@@ -3503,28 +3541,21 @@ def register():
     bpy.utils.register_class(BLENDERMCP_OT_StopServer)
     bpy.utils.register_class(BLENDERMCP_OT_OpenTerms)
 
-    # Auto-start the server so the MCP client can connect without manual UI interaction
-    scene = getattr(bpy.context, 'scene', None)
-    if scene is not None:
-        port = scene.blendermcp_port
-        auto_start = scene.blendermcp_auto_start_server
-    else:
-        port = 9876
-        auto_start = True
+    if _blendermcp_on_load_post not in bpy.app.handlers.load_post:
+        bpy.app.handlers.load_post.append(_blendermcp_on_load_post)
 
-    if auto_start and (not hasattr(bpy.types, "blendermcp_server") or not bpy.types.blendermcp_server):
-        bpy.types.blendermcp_server = BlenderMCPServer(port=port)
-    if auto_start and not bpy.types.blendermcp_server.running:
-        bpy.types.blendermcp_server.start()
-        try:
-            bpy.context.scene.blendermcp_server_running = bpy.types.blendermcp_server.running
-        except AttributeError:
-            pass
+    # Auto-start the server so the MCP client can connect without manual UI
+    # interaction. At Blender startup there is no scene yet, so the real work
+    # happens in the load_post handler once the .blend has been read; enabling
+    # the addon in a running Blender has a scene already and starts here.
+    _blendermcp_on_load_post()
 
     print("BlenderMCP addon registered")
 
 def unregister():
     _unregister_edit_capture_handlers()
+    with suppress(ValueError):
+        bpy.app.handlers.load_post.remove(_blendermcp_on_load_post)
 
     # Stop the server if it's running
     if hasattr(bpy.types, "blendermcp_server") and bpy.types.blendermcp_server:

--- a/src/blender_mcp/bundled/addon.py
+++ b/src/blender_mcp/bundled/addon.py
@@ -251,6 +251,38 @@ def _blendermcp_depsgraph_post(scene, depsgraph=None):
     _edit_recorder.poll_operators()
 
 
+# Set when the user clicks Disconnect, so that opening a .blend afterwards does
+# not silently bring the server back up behind them. An explicit Connect clears
+# it, as does restarting Blender (the addon re-registers).
+_user_stopped_server = False
+
+
+@persistent
+def _blendermcp_on_load_post(*args):
+    """Start the server against the loaded scene and re-sync the panel flag.
+
+    register() runs before Blender has read a .blend, so bpy.context.scene is
+    None at startup: the file's port cannot be read and blendermcp_server_running
+    cannot be written. load_post is the first point where the scene exists.
+    """
+    scene = getattr(bpy.context, "scene", None)
+    if scene is None:
+        return
+
+    server = getattr(bpy.types, "blendermcp_server", None)
+    if scene.blendermcp_auto_start_server and not _user_stopped_server:
+        if server is None:
+            server = BlenderMCPServer(port=scene.blendermcp_port)
+            bpy.types.blendermcp_server = server
+        if not server.running:
+            # Only safe to retarget while stopped; a running server keeps its
+            # port so an already-connected client is not dropped.
+            server.port = scene.blendermcp_port
+            server.start()
+
+    scene.blendermcp_server_running = bool(server is not None and server.running)
+
+
 def _telemetry_consent_enabled():
     """Read the consent preference directly. Fails closed."""
     try:
@@ -3277,7 +3309,9 @@ class BLENDERMCP_PT_Panel(bpy.types.Panel):
             layout.operator("blendermcp.start_server", text="Connect to MCP server")
         else:
             layout.operator("blendermcp.stop_server", text="Disconnect from MCP server")
-            layout.label(text=f"Running on port {scene.blendermcp_port}")
+            server = getattr(bpy.types, "blendermcp_server", None)
+            running_port = getattr(server, "port", scene.blendermcp_port)
+            layout.label(text=f"Running on port {running_port}")
         
         # Feedback section
         layout.separator()
@@ -3318,7 +3352,9 @@ class BLENDERMCP_OT_StartServer(bpy.types.Operator):
     bl_description = "Start the BlenderMCP server to connect with Claude"
 
     def execute(self, context):
+        global _user_stopped_server
         scene = context.scene
+        _user_stopped_server = False
 
         # Create a new server instance
         if not hasattr(bpy.types, "blendermcp_server") or not bpy.types.blendermcp_server:
@@ -3337,7 +3373,9 @@ class BLENDERMCP_OT_StopServer(bpy.types.Operator):
     bl_description = "Stop the connection to Claude"
 
     def execute(self, context):
+        global _user_stopped_server
         scene = context.scene
+        _user_stopped_server = True
 
         # Stop the server if it exists
         if hasattr(bpy.types, "blendermcp_server") and bpy.types.blendermcp_server:
@@ -3503,28 +3541,21 @@ def register():
     bpy.utils.register_class(BLENDERMCP_OT_StopServer)
     bpy.utils.register_class(BLENDERMCP_OT_OpenTerms)
 
-    # Auto-start the server so the MCP client can connect without manual UI interaction
-    scene = getattr(bpy.context, 'scene', None)
-    if scene is not None:
-        port = scene.blendermcp_port
-        auto_start = scene.blendermcp_auto_start_server
-    else:
-        port = 9876
-        auto_start = True
+    if _blendermcp_on_load_post not in bpy.app.handlers.load_post:
+        bpy.app.handlers.load_post.append(_blendermcp_on_load_post)
 
-    if auto_start and (not hasattr(bpy.types, "blendermcp_server") or not bpy.types.blendermcp_server):
-        bpy.types.blendermcp_server = BlenderMCPServer(port=port)
-    if auto_start and not bpy.types.blendermcp_server.running:
-        bpy.types.blendermcp_server.start()
-        try:
-            bpy.context.scene.blendermcp_server_running = bpy.types.blendermcp_server.running
-        except AttributeError:
-            pass
+    # Auto-start the server so the MCP client can connect without manual UI
+    # interaction. At Blender startup there is no scene yet, so the real work
+    # happens in the load_post handler once the .blend has been read; enabling
+    # the addon in a running Blender has a scene already and starts here.
+    _blendermcp_on_load_post()
 
     print("BlenderMCP addon registered")
 
 def unregister():
     _unregister_edit_capture_handlers()
+    with suppress(ValueError):
+        bpy.app.handlers.load_post.remove(_blendermcp_on_load_post)
 
     # Stop the server if it's running
     if hasattr(bpy.types, "blendermcp_server") and bpy.types.blendermcp_server:

--- a/tests/test_autostart_scene_state.py
+++ b/tests/test_autostart_scene_state.py
@@ -1,0 +1,153 @@
+"""Tests for auto-start binding the scene's port and syncing the panel flag.
+
+addon.py cannot be imported without bpy, so _blendermcp_on_load_post is lifted
+out by AST and executed against stubs.
+
+The bug these cover: auto-start ran at the end of register(), which at Blender
+startup happens before any .blend has been read. bpy.context.scene was None
+there, so the handler fell back to a hardcoded port 9876 - silently ignoring a
+port configured in the file - and the write to blendermcp_server_running was
+swallowed by `except AttributeError`. The panel keys its button off that flag,
+so it offered "Connect to MCP server" for an already-running server.
+"""
+
+from __future__ import annotations
+
+import ast
+import types
+
+from conftest import ROOT_ADDON
+
+
+class _FakeServer:
+    """Minimal stand-in for BlenderMCPServer; start() never touches sockets."""
+
+    def __init__(self, port):
+        self.port = port
+        self.running = False
+        self.start_calls = 0
+
+    def start(self):
+        self.start_calls += 1
+        self.running = True
+
+
+def _load_handler(scene, server=None, user_stopped=False):
+    """Compile _blendermcp_on_load_post from addon.py against stub modules."""
+    source = ROOT_ADDON.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    body = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "_blendermcp_on_load_post"
+    ]
+    assert body, "_blendermcp_on_load_post not found in addon.py"
+
+    bpy = types.ModuleType("bpy")
+    bpy.context = types.SimpleNamespace(scene=scene)
+    bpy.types = types.SimpleNamespace()
+    if server is not None:
+        bpy.types.blendermcp_server = server
+
+    namespace = {
+        "bpy": bpy,
+        "persistent": lambda fn: fn,
+        "BlenderMCPServer": _FakeServer,
+        "_user_stopped_server": user_stopped,
+    }
+    exec(compile(ast.Module(body=body, type_ignores=[]), "<addon>", "exec"), namespace)
+    return namespace["_blendermcp_on_load_post"], bpy
+
+
+def _scene(port=9876, auto_start=True, running=False):
+    return types.SimpleNamespace(
+        blendermcp_port=port,
+        blendermcp_auto_start_server=auto_start,
+        blendermcp_server_running=running,
+    )
+
+
+def test_starts_on_the_scene_port_not_a_hardcoded_default():
+    """A port configured in the .blend is honoured, not replaced by 9876."""
+    scene = _scene(port=9999)
+    handler, bpy = _load_handler(scene)
+
+    handler()
+
+    assert bpy.types.blendermcp_server.port == 9999
+    assert bpy.types.blendermcp_server.running is True
+
+
+def test_panel_flag_matches_a_running_server():
+    """The flag the panel reads is written once a scene exists."""
+    scene = _scene()
+    handler, _ = _load_handler(scene)
+
+    handler()
+
+    assert scene.blendermcp_server_running is True
+
+
+def test_panel_flag_resyncs_for_a_server_started_before_the_file_loaded():
+    """Opening a file resets the per-scene flag; the handler restores it.
+
+    This is the reported symptom: the server is up, but the freshly loaded
+    scene carries the property default (False) and the panel lies.
+    """
+    server = _FakeServer(port=9876)
+    server.running = True
+    scene = _scene(running=False)
+    handler, _ = _load_handler(scene, server=server)
+
+    handler()
+
+    assert scene.blendermcp_server_running is True
+    assert server.start_calls == 0, "an already-running server must not be restarted"
+
+
+def test_running_server_keeps_its_port_when_the_file_disagrees():
+    """Retargeting a live server would drop the connected client."""
+    server = _FakeServer(port=9876)
+    server.running = True
+    scene = _scene(port=9999)
+    handler, _ = _load_handler(scene, server=server)
+
+    handler()
+
+    assert server.port == 9876
+    assert scene.blendermcp_server_running is True
+
+
+def test_auto_start_disabled_leaves_the_server_alone():
+    scene = _scene(auto_start=False)
+    handler, bpy = _load_handler(scene)
+
+    handler()
+
+    assert not hasattr(bpy.types, "blendermcp_server")
+    assert scene.blendermcp_server_running is False
+
+
+def test_no_scene_is_a_no_op():
+    """register() calls the handler directly; at startup there is no scene."""
+    handler, bpy = _load_handler(None)
+
+    handler()
+
+    assert not hasattr(bpy.types, "blendermcp_server")
+
+
+def test_manual_disconnect_survives_opening_a_file():
+    """Opening a .blend must not resurrect a server the user shut off.
+
+    Disconnect deletes bpy.types.blendermcp_server, so without this guard the
+    handler would see no server and happily start a fresh one.
+    """
+    scene = _scene()
+    handler, bpy = _load_handler(scene, user_stopped=True)
+
+    handler()
+
+    assert not hasattr(bpy.types, "blendermcp_server")
+    assert scene.blendermcp_server_running is False


### PR DESCRIPTION
### Problem

On a normal Blender launch the addon auto-starts its server, but:

1. **A port configured in the .blend is silently ignored** — the server binds 9876 regardless. Clicking **Connect to MCP server** afterwards cannot correct it: the operator reuses the existing server object, and `start()` early-returns on `self.running`.
2. **The panel offers "Connect to MCP server" for a server that is already running.** Users click a button that does nothing but relabel itself, and reasonably conclude the integration is broken.

Both come from the same line. Auto-start (added in #254) runs at the end of `register()`, which at startup happens *before* Blender has read a .blend, so `bpy.context.scene` is `None`:

```python
scene = getattr(bpy.context, 'scene', None)
if scene is not None:
    port = scene.blendermcp_port
    auto_start = scene.blendermcp_auto_start_server
else:
    port = 9876          # <- configured port lost
    auto_start = True
...
    try:
        bpy.context.scene.blendermcp_server_running = bpy.types.blendermcp_server.running
    except AttributeError:
        pass             # <- always taken at startup; panel flag never set
```

#254 intended `blendermcp_server_running` to be set "so the UI panel reflects the correct state". It does when you enable the addon in an already-running Blender — which is how it was verified — but never on the cold-start path.

### Reproduction

Blender 5.2 LTS, Windows 11. Deterministic and headless, against an isolated config so it cannot disturb a real setup:

```bash
export BLENDER_USER_RESOURCES=/tmp/bmcp-probe        # addon copied to $_/scripts/addons/
# 1. enable the addon persistently and bake a custom port into the startup file
blender --background --python-expr '
import bpy, addon_utils
addon_utils.enable("addon", default_set=True, persistent=True)
bpy.context.scene.blendermcp_port = 9999
bpy.ops.wm.save_userpref(); bpy.ops.wm.save_homefile()'
# 2. relaunch - the addon is now enabled *before* launch, i.e. real cold-start order
blender --background --python-expr '
import bpy
srv = bpy.types.blendermcp_server
print("scene_port=%s server_port=%s panel_flag=%s" % (
    bpy.context.scene.blendermcp_port, srv.port,
    bpy.context.scene.blendermcp_server_running))'
```

| | before | after |
|---|---|---|
| `scene_port` | 9999 | 9999 |
| `server_port` | **9876** | **9999** |

`panel_flag` is `False` in both under `--background`, correctly — `start()` deliberately no-ops there, so no server is running to report. Verified separately in a GUI session: on a cold start with no clicks, the panel now reads **Disconnect from MCP server** and `blendermcp_server_running` is `True`.

### Fix

Move the work into a `@persistent` `load_post` handler — the first point at which a scene exists. `register()` appends the handler and calls it directly, so enabling the addon in a running Blender still starts the server immediately; at startup that direct call is a no-op and the handler does the work once the .blend is read. The hardcoded 9876 fallback is gone.

Behaviour deliberately preserved:

- **A running server keeps its port** when a newly opened file disagrees. Retargeting it would drop a connected client, so only a stopped server is retargeted.
- **An explicit Disconnect suppresses auto-start** until the user reconnects. `BLENDERMCP_OT_StopServer` does `del bpy.types.blendermcp_server`, so without this guard the handler would see no server on the next file open and silently bring one back up behind the user. Cleared by Connect and by restarting Blender.

Also: the panel's "Running on port N" label now reports the port the server actually bound rather than the scene's intent, so the two can no longer disagree.

`src/blender_mcp/bundled/addon.py` is kept in sync, per `test_root_and_bundled_addon_in_sync`.

### Tests

`tests/test_autostart_scene_state.py` — 7 cases, no Blender required, following the existing AST-lift-against-stubs convention in `test_server_threading.py`:

- starts on the scene's port instead of a hardcoded default
- writes the panel flag for a running server
- re-syncs the flag for a server started before the file loaded (the reported symptom) without restarting it
- a running server keeps its port when the file disagrees
- `auto_start` disabled leaves the server alone
- no scene is a no-op (the `register()` path)
- manual Disconnect survives opening a file

The six pre-existing-behaviour cases fail against unpatched `addon.py`. Full suite: 27 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
