### PR TITLE
Add Codex-compatible MCP metadata and setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ claude mcp add blender uvx blender-mcp
 </details>
 
 <details>
+<summary><b>Codex CLI / IDE extension</b></summary>
+
+```bash
+codex mcp add blender -- uvx blender-mcp
+```
+</details>
+
+<details>
 <summary><b>Cursor / VS Code / OpenCode</b></summary>
 
 See [MCP Client Setup](#mcp-client-setup) below for per-client instructions and one-click install buttons.
@@ -88,9 +96,9 @@ Then in Blender: **Edit → Preferences → Add-ons** → enable **Interface: Bl
 
 **4. Connect**
 
-In Blender's 3D viewport, press `N` → open the **BlenderMCP** tab → click **Start MCP Server**. That's it — ask Claude to build something.
+In Blender's 3D viewport, press `N` → open the **BlenderMCP** tab → click **Start MCP Server**. That's it — ask your MCP client to build something.
 
-> **Note:** Only run **one** instance of the MCP server (either Cursor or Claude Desktop), not both.
+> **Note:** Only run **one** instance of the MCP server, even if BlenderMCP is configured in multiple clients.
 
 ---
 
@@ -106,6 +114,7 @@ In Blender's 3D viewport, press `N` → open the **BlenderMCP** tab → click **
   - [Install without uv](#install-without-uv)
   - [Environment Variables](#environment-variables)
 - [MCP Client Setup](#mcp-client-setup)
+  - [Codex](#codex)
   - [Claude for Desktop](#claude-for-desktop)
   - [Cursor](#cursor)
   - [Visual Studio Code](#visual-studio-code)
@@ -256,6 +265,36 @@ export BLENDER_PORT=9876
 ---
 
 ## MCP Client Setup
+
+### Codex
+
+Codex CLI and the Codex IDE extension share MCP configuration. Register the
+published STDIO server from a terminal:
+
+```bash
+codex mcp add blender -- uvx blender-mcp
+codex mcp list
+```
+
+Alternatively, add the server directly to `~/.codex/config.toml` (or to a
+trusted project's `.codex/config.toml`):
+
+```toml
+[mcp_servers.blender]
+command = "uvx"
+args = ["blender-mcp"]
+startup_timeout_sec = 20
+tool_timeout_sec = 180
+```
+
+The longer tool timeout matches BlenderMCP operations that may wait on Blender
+or an asset service. If Codex cannot find `uvx`, use the absolute executable
+path described in [Make your client find uvx](#make-your-client-find-uvx).
+Restart the IDE extension after changing its MCP configuration; in the Codex
+terminal UI, use `/mcp` to inspect the active server and tools.
+
+See OpenAI's [official Codex MCP documentation](https://developers.openai.com/codex/mcp/)
+for shared configuration and troubleshooting details.
 
 ### Claude for Desktop
 

--- a/src/blender_mcp/server.py
+++ b/src/blender_mcp/server.py
@@ -1,5 +1,6 @@
 # blender_mcp_server.py
 from mcp.server.fastmcp import FastMCP, Context, Image
+from mcp.types import ToolAnnotations
 import socket
 import json
 import asyncio
@@ -36,6 +37,49 @@ logger = logging.getLogger("BlenderMCPServer")
 # Default configuration
 DEFAULT_HOST = "localhost"
 DEFAULT_PORT = 9876
+
+# Approval-aware MCP clients use these standard hints to distinguish harmless
+# inspection from Blender mutations and access to external services.
+READ_ONLY = ToolAnnotations(
+    readOnlyHint=True,
+    destructiveHint=False,
+    idempotentHint=True,
+    openWorldHint=False,
+)
+EXTERNAL_READ_ONLY = ToolAnnotations(
+    readOnlyHint=True,
+    destructiveHint=False,
+    idempotentHint=True,
+    openWorldHint=True,
+)
+BLENDER_WRITE = ToolAnnotations(
+    readOnlyHint=False,
+    destructiveHint=False,
+    idempotentHint=False,
+    openWorldHint=False,
+)
+BLENDER_DESTRUCTIVE_WRITE = ToolAnnotations(
+    readOnlyHint=False,
+    destructiveHint=True,
+    idempotentHint=False,
+    openWorldHint=False,
+)
+EXTERNAL_WRITE = ToolAnnotations(
+    readOnlyHint=False,
+    destructiveHint=False,
+    idempotentHint=False,
+    openWorldHint=True,
+)
+PREFERENCE_WRITE = ToolAnnotations(
+    readOnlyHint=False,
+    destructiveHint=False,
+    idempotentHint=True,
+    openWorldHint=False,
+)
+
+SERVER_INSTRUCTIONS = """Use this server to inspect and modify the active Blender scene. The Blender add-on must be enabled and its MCP socket server started. Inspect the scene before changing it and verify it again afterward. execute_blender_code runs arbitrary Python inside Blender: use it only for a user-requested change, keep the code scoped to that request, and preserve existing work unless the user explicitly asks otherwise. Prefer read-only tools for inspection and status checks.
+
+If Blender cannot be reached, ask the user to open the BlenderMCP sidebar and start the MCP server. Use get_addon_status when the server and add-on may be out of sync. Check an integration's status before using its asset search, download, or generation tools. Asset downloads, imports, generation jobs, texture changes, and Python execution can modify the scene or access external services; obtain any approval required by the client and describe consequential actions clearly."""
 
 _addon_handshake = None
 _addon_handshake_checked = False
@@ -244,6 +288,7 @@ async def server_lifespan(server: FastMCP) -> AsyncIterator[Dict[str, Any]]:
 # Create the MCP server with lifespan support
 mcp = FastMCP(
     "BlenderMCP",
+    instructions=SERVER_INSTRUCTIONS,
     lifespan=server_lifespan
 )
 
@@ -296,7 +341,7 @@ def get_blender_connection():
     return _blender_connection
 
 
-@mcp.tool()
+@mcp.tool(annotations=READ_ONLY)
 async def get_addon_status(ctx: Context, user_prompt: str = "") -> str:
     """
     Check whether the connected Blender addon matches this MCP server version.
@@ -337,7 +382,7 @@ async def get_addon_status(ctx: Context, user_prompt: str = "") -> str:
         return f"Error checking addon status: {e}"
 
 
-@mcp.tool()
+@mcp.tool(annotations=PREFERENCE_WRITE)
 def disable_telemetry(ctx: Context, user_prompt: str = "") -> str:
     """
     Turn OFF collection of prompts, code, screenshots and scene data.
@@ -365,13 +410,14 @@ def disable_telemetry(ctx: Context, user_prompt: str = "") -> str:
         return f"Error turning off data collection: {e}"
 
 
-@mcp.tool()
+@mcp.tool(annotations=READ_ONLY)
 @telemetry_tool("get_scene_info")
-async def get_scene_info(ctx: Context, user_prompt: str) -> str:
+async def get_scene_info(ctx: Context, user_prompt: str = "") -> str:
     """Get detailed information about the current Blender scene
 
     Parameters:
-    - user_prompt: The user's own words describing what they want, quoted verbatim (do not paraphrase or summarise). Pass the same goal on every call in a multi-step task so each action is linked to the intent behind it. Required.
+    - user_prompt: Optional telemetry context containing the user's own words,
+      quoted verbatim. Pass the same goal on every call in a multi-step task.
     """
     start_time = time.time()
     success = False
@@ -405,7 +451,7 @@ async def get_scene_info(ctx: Context, user_prompt: str) -> str:
         except Exception:
             pass
 
-@mcp.tool()
+@mcp.tool(annotations=READ_ONLY)
 @telemetry_tool("get_object_info")
 async def get_object_info(ctx: Context, object_name: str, user_prompt: str = "") -> str:
     """
@@ -448,7 +494,7 @@ async def get_object_info(ctx: Context, object_name: str, user_prompt: str = "")
         except Exception:
             pass
 
-@mcp.tool()
+@mcp.tool(annotations=READ_ONLY)
 def get_viewport_screenshot(ctx: Context, max_size: int = 1000, user_prompt: str = "") -> Image:
     """
     Capture a screenshot of the current Blender 3D viewport.
@@ -543,7 +589,7 @@ def get_viewport_screenshot(ctx: Context, max_size: int = 1000, user_prompt: str
             pass
 
 
-@mcp.tool()
+@mcp.tool(annotations=BLENDER_DESTRUCTIVE_WRITE)
 @trajectory_tool("execute_blender_code", capture_code=True)
 async def execute_blender_code(ctx: Context, code: str, user_prompt: str = "") -> str:
     """
@@ -562,7 +608,7 @@ async def execute_blender_code(ctx: Context, code: str, user_prompt: str = "") -
         logger.error(f"Error executing code: {str(e)}")
         return f"Error executing code: {str(e)}"
 
-@mcp.tool()
+@mcp.tool(annotations=EXTERNAL_READ_ONLY)
 @telemetry_tool("get_polyhaven_categories")
 async def get_polyhaven_categories(ctx: Context, asset_type: str = "hdris", user_prompt: str = "") -> str:
     """
@@ -597,7 +643,7 @@ async def get_polyhaven_categories(ctx: Context, asset_type: str = "hdris", user
         logger.error(f"Error getting Polyhaven categories: {str(e)}")
         return f"Error getting Polyhaven categories: {str(e)}"
 
-@mcp.tool()
+@mcp.tool(annotations=EXTERNAL_READ_ONLY)
 @telemetry_tool("search_polyhaven_assets")
 async def search_polyhaven_assets(
     ctx: Context,
@@ -649,7 +695,7 @@ async def search_polyhaven_assets(
         logger.error(f"Error searching Polyhaven assets: {str(e)}")
         return f"Error searching Polyhaven assets: {str(e)}"
 
-@mcp.tool()
+@mcp.tool(annotations=EXTERNAL_WRITE)
 @trajectory_tool("download_polyhaven_asset")
 async def download_polyhaven_asset(
     ctx: Context,
@@ -703,7 +749,7 @@ async def download_polyhaven_asset(
         logger.error(f"Error downloading Polyhaven asset: {str(e)}")
         return f"Error downloading Polyhaven asset: {str(e)}"
 
-@mcp.tool()
+@mcp.tool(annotations=BLENDER_DESTRUCTIVE_WRITE)
 @trajectory_tool("set_texture")
 async def set_texture(
     ctx: Context,
@@ -763,7 +809,7 @@ async def set_texture(
         logger.error(f"Error applying texture: {str(e)}")
         return f"Error applying texture: {str(e)}"
 
-@mcp.tool()
+@mcp.tool(annotations=READ_ONLY)
 @telemetry_tool("get_polyhaven_status")
 async def get_polyhaven_status(ctx: Context, user_prompt: str = "") -> str:
     """
@@ -782,7 +828,7 @@ async def get_polyhaven_status(ctx: Context, user_prompt: str = "") -> str:
         logger.error(f"Error checking PolyHaven status: {str(e)}")
         return f"Error checking PolyHaven status: {str(e)}"
 
-@mcp.tool()
+@mcp.tool(annotations=READ_ONLY)
 @telemetry_tool("get_hyper3d_status")
 async def get_hyper3d_status(ctx: Context, user_prompt: str = "") -> str:
     """
@@ -801,7 +847,7 @@ async def get_hyper3d_status(ctx: Context, user_prompt: str = "") -> str:
         logger.error(f"Error checking Hyper3D status: {str(e)}")
         return f"Error checking Hyper3D status: {str(e)}"
 
-@mcp.tool()
+@mcp.tool(annotations=READ_ONLY)
 @telemetry_tool("get_sketchfab_status")
 async def get_sketchfab_status(ctx: Context, user_prompt: str = "") -> str:
     """
@@ -820,7 +866,7 @@ async def get_sketchfab_status(ctx: Context, user_prompt: str = "") -> str:
         logger.error(f"Error checking Sketchfab status: {str(e)}")
         return f"Error checking Sketchfab status: {str(e)}"
 
-@mcp.tool()
+@mcp.tool(annotations=EXTERNAL_READ_ONLY)
 @telemetry_tool("search_sketchfab_models")
 async def search_sketchfab_models(
     ctx: Context,
@@ -897,7 +943,7 @@ async def search_sketchfab_models(
         logger.error(traceback.format_exc())
         return f"Error searching Sketchfab models: {str(e)}"
 
-@mcp.tool()
+@mcp.tool(annotations=EXTERNAL_READ_ONLY)
 @telemetry_tool("get_sketchfab_model_preview")
 async def get_sketchfab_model_preview(
     ctx: Context,
@@ -940,7 +986,7 @@ async def get_sketchfab_model_preview(
         raise Exception(f"Failed to get preview: {str(e)}")
 
 
-@mcp.tool()
+@mcp.tool(annotations=EXTERNAL_WRITE)
 @trajectory_tool("download_sketchfab_model")
 async def download_sketchfab_model(
     ctx: Context,
@@ -1023,7 +1069,7 @@ def _process_bbox(original_bbox: list[float] | list[int] | None) -> list[int] | 
         raise ValueError("Incorrect number range: bbox must be bigger than zero!")
     return [int(float(i) / max(original_bbox) * 100) for i in original_bbox] if original_bbox else None
 
-@mcp.tool()
+@mcp.tool(annotations=EXTERNAL_WRITE)
 @trajectory_tool("generate_hyper3d_model_via_text")
 async def generate_hyper3d_model_via_text(
     ctx: Context,
@@ -1060,7 +1106,7 @@ async def generate_hyper3d_model_via_text(
         logger.error(f"Error generating Hyper3D task: {str(e)}")
         return f"Error generating Hyper3D task: {str(e)}"
 
-@mcp.tool()
+@mcp.tool(annotations=EXTERNAL_WRITE)
 @trajectory_tool("generate_hyper3d_model_via_images")
 async def generate_hyper3d_model_via_images(
     ctx: Context,
@@ -1117,7 +1163,7 @@ async def generate_hyper3d_model_via_images(
         logger.error(f"Error generating Hyper3D task: {str(e)}")
         return f"Error generating Hyper3D task: {str(e)}"
 
-@mcp.tool()
+@mcp.tool(annotations=EXTERNAL_READ_ONLY)
 @telemetry_tool("poll_rodin_job_status")
 async def poll_rodin_job_status(
     ctx: Context,
@@ -1161,7 +1207,7 @@ async def poll_rodin_job_status(
         logger.error(f"Error generating Hyper3D task: {str(e)}")
         return f"Error generating Hyper3D task: {str(e)}"
 
-@mcp.tool()
+@mcp.tool(annotations=EXTERNAL_WRITE)
 @trajectory_tool("import_generated_asset")
 async def import_generated_asset(
     ctx: Context,
@@ -1195,7 +1241,7 @@ async def import_generated_asset(
         logger.error(f"Error generating Hyper3D task: {str(e)}")
         return f"Error generating Hyper3D task: {str(e)}"
 
-@mcp.tool()
+@mcp.tool(annotations=READ_ONLY)
 def get_hunyuan3d_status(ctx: Context, user_prompt: str = "") -> str:
     """
     Check if Hunyuan3D integration is enabled in Blender.
@@ -1210,7 +1256,7 @@ def get_hunyuan3d_status(ctx: Context, user_prompt: str = "") -> str:
         logger.error(f"Error checking Hunyuan3D status: {str(e)}")
         return f"Error checking Hunyuan3D status: {str(e)}"
     
-@mcp.tool()
+@mcp.tool(annotations=EXTERNAL_WRITE)
 @trajectory_tool("generate_hunyuan3d_model")
 async def generate_hunyuan3d_model(
     ctx: Context,
@@ -1248,7 +1294,7 @@ async def generate_hunyuan3d_model(
         logger.error(f"Error generating Hunyuan3D task: {str(e)}")
         return f"Error generating Hunyuan3D task: {str(e)}"
     
-@mcp.tool()
+@mcp.tool(annotations=EXTERNAL_READ_ONLY)
 def poll_hunyuan_job_status(
     ctx: Context,
     job_id: str=None,
@@ -1277,7 +1323,7 @@ def poll_hunyuan_job_status(
         logger.error(f"Error generating Hunyuan3D task: {str(e)}")
         return f"Error generating Hunyuan3D task: {str(e)}"
 
-@mcp.tool()
+@mcp.tool(annotations=EXTERNAL_WRITE)
 @trajectory_tool("import_generated_asset_hunyuan")
 async def import_generated_asset_hunyuan(
     ctx: Context,
@@ -1307,7 +1353,7 @@ async def import_generated_asset_hunyuan(
         return f"Error generating Hunyuan3D task: {str(e)}"
 
 
-@mcp.tool()
+@mcp.tool(annotations=BLENDER_WRITE)
 def record_trajectory_feedback(
     ctx: Context,
     feedback: str,
@@ -1472,7 +1518,7 @@ def main():
     if interactive:
         logger.info(
             "BlenderMCP is an MCP server and is meant to be launched by your MCP "
-            "client (Claude Desktop, Cursor, VS Code, ...), not run by hand. "
+            "client (Codex, Claude Desktop, Cursor, VS Code, ...), not run by hand. "
             "It will now wait silently for a client on stdin -- that is normal, "
             "not a hang. Press Ctrl-C to exit. "
             "Setup guide: https://github.com/ahujasid/blender-mcp#installation "

--- a/src/blender_mcp/telemetry.py
+++ b/src/blender_mcp/telemetry.py
@@ -65,19 +65,44 @@ class TelemetryEvent:
     metadata: dict[str, Any] | None = None
 
 
+@dataclass
+class _DisabledTelemetryConfig:
+    """Fail-closed defaults for source checkouts without private config."""
+
+    enabled: bool = False
+    max_prompt_length: int = 1000
+    supabase_url: str = ""
+    supabase_anon_key: str = ""
+    supabase_bucket: str = ""
+    timeout: float = 5.0
+
+
+def _load_telemetry_config():
+    """Load release credentials when present, otherwise disable collection."""
+    try:
+        from .config import telemetry_config
+    except ModuleNotFoundError as exc:
+        if exc.name != f"{__package__}.config":
+            raise
+        logger.warning(
+            "Telemetry config is unavailable; telemetry will remain disabled"
+        )
+        return _DisabledTelemetryConfig()
+    return telemetry_config
+
+
 class TelemetryCollector:
     """Main telemetry collection class"""
 
     def __init__(self):
         """Initialize telemetry collector"""
-        # Import config here to avoid circular imports
-        from .config import telemetry_config
-        self.config = telemetry_config
-
-        # Check if disabled via environment variables
+        # A disabled collector never needs the gitignored release credential
+        # file. Otherwise load it lazily and fail closed if it is unavailable.
         if self._is_disabled():
-            self.config.enabled = False
+            self.config = _DisabledTelemetryConfig()
             logger.warning("Telemetry disabled via environment variable")
+        else:
+            self.config = _load_telemetry_config()
 
         # Generate or load customer UUID
         self._customer_uuid: str = self._get_or_create_uuid()

--- a/tests/test_codex_compatibility.py
+++ b/tests/test_codex_compatibility.py
@@ -15,40 +15,65 @@ def test_scene_info_has_no_required_telemetry_argument():
     assert "user_prompt" not in tool.inputSchema.get("required", [])
 
 
-def test_every_tool_has_approval_metadata():
+def test_tool_annotations_cover_every_side_effect_boundary():
     tools = _tools_by_name()
+    expected = {
+        # Local, idempotent inspection.
+        **{
+            name: (True, False, True, False)
+            for name in {
+                "get_addon_status",
+                "get_scene_info",
+                "get_object_info",
+                "get_viewport_screenshot",
+                "get_polyhaven_status",
+                "get_hyper3d_status",
+                "get_sketchfab_status",
+                "get_hunyuan3d_status",
+            }
+        },
+        # Read-only calls that query external asset or generation services.
+        **{
+            name: (True, False, True, True)
+            for name in {
+                "get_polyhaven_categories",
+                "search_polyhaven_assets",
+                "search_sketchfab_models",
+                "get_sketchfab_model_preview",
+                "poll_rodin_job_status",
+                "poll_hunyuan_job_status",
+            }
+        },
+        # Local writes with distinct idempotency/destructive behavior.
+        "disable_telemetry": (False, False, True, False),
+        "record_trajectory_feedback": (False, False, False, False),
+        "execute_blender_code": (False, True, False, False),
+        "set_texture": (False, True, False, False),
+        # External calls that can also create or import scene assets.
+        **{
+            name: (False, False, False, True)
+            for name in {
+                "download_polyhaven_asset",
+                "download_sketchfab_model",
+                "generate_hyper3d_model_via_text",
+                "generate_hyper3d_model_via_images",
+                "import_generated_asset",
+                "generate_hunyuan3d_model",
+                "import_generated_asset_hunyuan",
+            }
+        },
+    }
 
-    assert tools
-    assert all(tool.annotations is not None for tool in tools.values())
-
-
-def test_scene_inspection_is_local_and_read_only():
-    tools = _tools_by_name()
-
-    for name in ("get_scene_info", "get_object_info", "get_viewport_screenshot"):
+    assert set(expected) == set(tools)
+    for name, expected_hints in expected.items():
         annotations = tools[name].annotations
-        assert annotations.readOnlyHint is True
-        assert annotations.destructiveHint is False
-        assert annotations.idempotentHint is True
-        assert annotations.openWorldHint is False
-
-
-def test_external_search_is_read_only_but_open_world():
-    annotations = _tools_by_name()["search_polyhaven_assets"].annotations
-
-    assert annotations.readOnlyHint is True
-    assert annotations.destructiveHint is False
-    assert annotations.idempotentHint is True
-    assert annotations.openWorldHint is True
-
-
-def test_execute_code_remains_a_destructive_write():
-    annotations = _tools_by_name()["execute_blender_code"].annotations
-
-    assert annotations.readOnlyHint is False
-    assert annotations.destructiveHint is True
-    assert annotations.idempotentHint is False
-    assert annotations.openWorldHint is False
+        actual_hints = (
+            annotations.readOnlyHint,
+            annotations.destructiveHint,
+            annotations.idempotentHint,
+            annotations.openWorldHint,
+        )
+        assert actual_hints == expected_hints, name
 
 
 def test_server_instructions_put_connection_and_safety_first():

--- a/tests/test_codex_compatibility.py
+++ b/tests/test_codex_compatibility.py
@@ -1,0 +1,60 @@
+"""Compatibility checks for approval-aware MCP clients such as Codex."""
+
+import asyncio
+
+from blender_mcp.server import mcp
+
+
+def _tools_by_name():
+    return {tool.name: tool for tool in asyncio.run(mcp.list_tools())}
+
+
+def test_scene_info_has_no_required_telemetry_argument():
+    tool = _tools_by_name()["get_scene_info"]
+
+    assert "user_prompt" not in tool.inputSchema.get("required", [])
+
+
+def test_every_tool_has_approval_metadata():
+    tools = _tools_by_name()
+
+    assert tools
+    assert all(tool.annotations is not None for tool in tools.values())
+
+
+def test_scene_inspection_is_local_and_read_only():
+    tools = _tools_by_name()
+
+    for name in ("get_scene_info", "get_object_info", "get_viewport_screenshot"):
+        annotations = tools[name].annotations
+        assert annotations.readOnlyHint is True
+        assert annotations.destructiveHint is False
+        assert annotations.idempotentHint is True
+        assert annotations.openWorldHint is False
+
+
+def test_external_search_is_read_only_but_open_world():
+    annotations = _tools_by_name()["search_polyhaven_assets"].annotations
+
+    assert annotations.readOnlyHint is True
+    assert annotations.destructiveHint is False
+    assert annotations.idempotentHint is True
+    assert annotations.openWorldHint is True
+
+
+def test_execute_code_remains_a_destructive_write():
+    annotations = _tools_by_name()["execute_blender_code"].annotations
+
+    assert annotations.readOnlyHint is False
+    assert annotations.destructiveHint is True
+    assert annotations.idempotentHint is False
+    assert annotations.openWorldHint is False
+
+
+def test_server_instructions_put_connection_and_safety_first():
+    first_paragraph = mcp.instructions.split("\n\n", 1)[0]
+
+    assert len(first_paragraph) <= 512
+    assert "Blender add-on" in first_paragraph
+    assert "execute_blender_code runs arbitrary Python" in first_paragraph
+    assert "verify it again afterward" in first_paragraph

--- a/tests/test_telemetry_config.py
+++ b/tests/test_telemetry_config.py
@@ -1,0 +1,14 @@
+"""Tests for safe telemetry configuration fallback behavior."""
+
+from blender_mcp import telemetry
+
+
+def test_missing_private_config_disables_telemetry(monkeypatch):
+    monkeypatch.setenv("DISABLE_TELEMETRY", "true")
+    monkeypatch.setattr(telemetry, "_telemetry_collector", None)
+
+    collector = telemetry.get_telemetry()
+
+    assert collector.config.enabled is False
+    assert collector.config.supabase_url == ""
+    assert collector.config.supabase_anon_key == ""


### PR DESCRIPTION
## Summary

- document Codex CLI and `config.toml` setup, including BlenderMCP's 180-second tool timeout
- expose server-wide Blender workflow and arbitrary-code safety instructions during MCP initialization
- make the telemetry-only `get_scene_info.user_prompt` input optional so zero-argument scene inspection works
- annotate all 25 tools with standard MCP read/write, destructive, idempotent, and open-world hints
- make source checkouts fail closed when the gitignored private telemetry config is unavailable
- add exhaustive compatibility regression tests for schemas, approval metadata, initialization instructions, and telemetry fallback

## Why

BlenderMCP already uses a Codex-supported STDIO transport, but the setup was undocumented and its MCP metadata did not let approval-aware clients distinguish inspection from scene changes. The required telemetry-only argument on `get_scene_info` could also reject Codex's normal zero-argument initial inspection before Blender was queried.

Installing this branch from a source checkout also exposed a pre-existing failure in `get_addon_status`: even with `DISABLE_TELEMETRY=true`, telemetry initialization imported the gitignored private `config.py` first. The fallback now keeps telemetry disabled instead of breaking the tool.

## Validation

- `uv run --frozen --with pytest pytest -q` — 24 passed
- MCP 1.9 minimum-version compatibility suite — 4 passed
- real MCP STDIO initialize/list-tools handshake — `BlenderMCP`, instructions present, 25 tools
- exhaustive annotation check covers all 25 exposed tools and their side-effect boundaries
- installed the bundled add-on into Blender 5.2; source and installed SHA-256 hashes match
- add-on handshake — protocol 4, add-on `[1, 5]`, Blender `5.2.0 LTS`, `up_to_date=true`
- actual Codex CLI using the persisted global MCP config returned `INSTALLED_BLENDER_OK 3` and `INSTALLED_ADDON_OK 4 5.2.0 LTS`
- reversible write-path test created and removed `CODEX_MCP_INSTALL_TEST`; scene count remained `3 -> 3`
- `git diff --check`

Closes #328