### PR TITLE
feat: International (Pro) account toggle for Hunyuan3D Official API

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,19 @@ Once the config file has been set on Claude, and the addon is running on Blender
 - Search and download low-poly models from [Poly Pizza](https://poly.pizza/)
 - AI generated 3D models through [Hyper3D Rodin](https://hyper3d.ai/) and [Hunyuan3D](https://3d.hunyuan.tencent.com/)
 
+#### Hunyuan3D on Tencent Cloud (Official API mode)
+
+Which Tencent Cloud service the addon must call depends on where your account lives:
+
+| Account | Service the addon calls | Region | Sidebar toggle |
+|---|---|---|---|
+| Mainland (cloud.tencent.com) | AI3D 3.0 (`ai3d`, version `2025-05-13`) | `ap-guangzhou` | leave **International (Pro) account** off (default) |
+| International (tencentcloud.com), *Hunyuan-to-3D (Professional)* | `hunyuan`, version `2023-09-01`, PBR enabled | `ap-singapore` | tick **International (Pro) account** |
+
+International credentials sent to the mainland endpoint fail with `AuthFailure.SignatureFailure` or
+`ResourceUnavailable`, so tick the toggle when your SecretId/SecretKey come from tencentcloud.com.
+The toggle sits under **Tencent Hunyuan 3D → Official API** in the sidebar.
+
 #### Poly Pizza
 
 [Poly Pizza](https://poly.pizza/) hosts roughly 10,600 free low-poly models, including the

--- a/addon.py
+++ b/addon.py
@@ -442,6 +442,38 @@ def get_blendermcp_addon_preferences(context=None):
     addon = context.preferences.addons.get(__name__)
     return addon.preferences if addon else None
 
+# Tencent Cloud exposes Hunyuan-to-3D through two different services depending on where the
+# account was created. Mainland accounts (cloud.tencent.com) use the AI3D 3.0 API. Tencent Cloud
+# International accounts (tencentcloud.com) use the "Hunyuan-to-3D (Professional)" service on the
+# older hunyuan API in ap-singapore; it rejects the mainland body fields and expects EnablePBR.
+# Sending International credentials to the mainland endpoint fails with
+# AuthFailure.SignatureFailure / ResourceUnavailable.
+HUNYUAN_API_PROFILES = {
+    "mainland": {
+        "service": "ai3d",
+        "version": "2025-05-13",
+        "region": "ap-guangzhou",
+        "submit_action": "SubmitHunyuanTo3DProJob",
+        "query_action": "QueryHunyuanTo3DProJob",
+        "submit_body": {},
+    },
+    "international_pro": {
+        "service": "hunyuan",
+        "version": "2023-09-01",
+        "region": "ap-singapore",
+        "submit_action": "SubmitHunyuanTo3DProJob",
+        "query_action": "QueryHunyuanTo3DProJob",
+        "submit_body": {"EnablePBR": True},
+    },
+}
+
+
+def hunyuan_api_profile(international_pro: bool) -> dict:
+    """Return a copy of the Tencent Cloud API profile for the selected account type."""
+    profile = HUNYUAN_API_PROFILES["international_pro" if international_pro else "mainland"]
+    return {**profile, "submit_body": dict(profile["submit_body"])}
+
+
 class BlenderMCPServer:
     def __init__(self, host='localhost', port=9876):
         self.host = host
@@ -3403,11 +3435,12 @@ class BlenderMCPServer:
                 return {"error": "Prompt or Image is required"}
             if text_prompt and image:
                 return {"error": "Prompt and Image cannot be provided simultaneously"}
-            # Updated to Tencent Cloud AI3D API 3.0 (2025-05-13)
-            service = "ai3d"
-            action = "SubmitHunyuanTo3DProJob"
-            version = "2025-05-13"
-            region = "ap-guangzhou"
+            profile = hunyuan_api_profile(
+                getattr(bpy.context.scene, "blendermcp_hunyuan3d_intl_pro", False))
+            service = profile["service"]
+            action = profile["submit_action"]
+            version = profile["version"]
+            region = profile["region"]
 
             headParams={
                 "Action": action,
@@ -3416,7 +3449,7 @@ class BlenderMCPServer:
             }
 
             # Constructing request parameters
-            data = {}
+            data = profile["submit_body"]
 
             # Handling text prompts
             if text_prompt:
@@ -3549,11 +3582,12 @@ class BlenderMCPServer:
             if not job_id:
                 return {"error": "JobId is required"}
             
-            # Updated to Tencent Cloud AI3D API 3.0 (2025-05-13)
-            service = "ai3d"
-            action = "QueryHunyuanTo3DProJob"
-            version = "2025-05-13"
-            region = "ap-guangzhou"
+            profile = hunyuan_api_profile(
+                getattr(bpy.context.scene, "blendermcp_hunyuan3d_intl_pro", False))
+            service = profile["service"]
+            action = profile["query_action"]
+            version = profile["version"]
+            region = profile["region"]
 
             headParams={
                 "Action": action,
@@ -3858,6 +3892,7 @@ class BLENDERMCP_PT_Panel(bpy.types.Panel):
                 else:
                     col.prop(scene, "blendermcp_hunyuan3d_secret_id", text="SecretId")
                     col.prop(scene, "blendermcp_hunyuan3d_secret_key", text="SecretKey")
+                col.prop(scene, "blendermcp_hunyuan3d_intl_pro", text="International (Pro) account")
             if scene.blendermcp_hunyuan3d_mode == 'LOCAL_API':
                 if prefs:
                     col.prop(prefs, "hunyuan3d_api_url", text="API URL")
@@ -4018,6 +4053,14 @@ def register():
         default="LOCAL_API"
     )
 
+    bpy.types.Scene.blendermcp_hunyuan3d_intl_pro = bpy.props.BoolProperty(
+        name="International (Pro)",
+        description="Use the Tencent Cloud International 'Hunyuan-to-3D (Professional)' service "
+                    "(hunyuan API, region ap-singapore, PBR enabled). Enable this when your SecretId/"
+                    "SecretKey come from tencentcloud.com; leave it off for mainland AI3D 3.0 accounts",
+        default=False
+    )
+
     bpy.types.Scene.blendermcp_hunyuan3d_secret_id = bpy.props.StringProperty(
         name="Hunyuan 3D SecretId",
         description="SecretId provided by Hunyuan 3D",
@@ -4150,6 +4193,7 @@ def unregister():
     del bpy.types.Scene.blendermcp_polypizza_api_key
     del bpy.types.Scene.blendermcp_use_hunyuan3d
     del bpy.types.Scene.blendermcp_hunyuan3d_mode
+    del bpy.types.Scene.blendermcp_hunyuan3d_intl_pro
     del bpy.types.Scene.blendermcp_hunyuan3d_secret_id
     del bpy.types.Scene.blendermcp_hunyuan3d_secret_key
     del bpy.types.Scene.blendermcp_hunyuan3d_api_url

--- a/src/blender_mcp/bundled/addon.py
+++ b/src/blender_mcp/bundled/addon.py
@@ -442,6 +442,38 @@ def get_blendermcp_addon_preferences(context=None):
     addon = context.preferences.addons.get(__name__)
     return addon.preferences if addon else None
 
+# Tencent Cloud exposes Hunyuan-to-3D through two different services depending on where the
+# account was created. Mainland accounts (cloud.tencent.com) use the AI3D 3.0 API. Tencent Cloud
+# International accounts (tencentcloud.com) use the "Hunyuan-to-3D (Professional)" service on the
+# older hunyuan API in ap-singapore; it rejects the mainland body fields and expects EnablePBR.
+# Sending International credentials to the mainland endpoint fails with
+# AuthFailure.SignatureFailure / ResourceUnavailable.
+HUNYUAN_API_PROFILES = {
+    "mainland": {
+        "service": "ai3d",
+        "version": "2025-05-13",
+        "region": "ap-guangzhou",
+        "submit_action": "SubmitHunyuanTo3DProJob",
+        "query_action": "QueryHunyuanTo3DProJob",
+        "submit_body": {},
+    },
+    "international_pro": {
+        "service": "hunyuan",
+        "version": "2023-09-01",
+        "region": "ap-singapore",
+        "submit_action": "SubmitHunyuanTo3DProJob",
+        "query_action": "QueryHunyuanTo3DProJob",
+        "submit_body": {"EnablePBR": True},
+    },
+}
+
+
+def hunyuan_api_profile(international_pro: bool) -> dict:
+    """Return a copy of the Tencent Cloud API profile for the selected account type."""
+    profile = HUNYUAN_API_PROFILES["international_pro" if international_pro else "mainland"]
+    return {**profile, "submit_body": dict(profile["submit_body"])}
+
+
 class BlenderMCPServer:
     def __init__(self, host='localhost', port=9876):
         self.host = host
@@ -3403,11 +3435,12 @@ class BlenderMCPServer:
                 return {"error": "Prompt or Image is required"}
             if text_prompt and image:
                 return {"error": "Prompt and Image cannot be provided simultaneously"}
-            # Updated to Tencent Cloud AI3D API 3.0 (2025-05-13)
-            service = "ai3d"
-            action = "SubmitHunyuanTo3DProJob"
-            version = "2025-05-13"
-            region = "ap-guangzhou"
+            profile = hunyuan_api_profile(
+                getattr(bpy.context.scene, "blendermcp_hunyuan3d_intl_pro", False))
+            service = profile["service"]
+            action = profile["submit_action"]
+            version = profile["version"]
+            region = profile["region"]
 
             headParams={
                 "Action": action,
@@ -3416,7 +3449,7 @@ class BlenderMCPServer:
             }
 
             # Constructing request parameters
-            data = {}
+            data = profile["submit_body"]
 
             # Handling text prompts
             if text_prompt:
@@ -3549,11 +3582,12 @@ class BlenderMCPServer:
             if not job_id:
                 return {"error": "JobId is required"}
             
-            # Updated to Tencent Cloud AI3D API 3.0 (2025-05-13)
-            service = "ai3d"
-            action = "QueryHunyuanTo3DProJob"
-            version = "2025-05-13"
-            region = "ap-guangzhou"
+            profile = hunyuan_api_profile(
+                getattr(bpy.context.scene, "blendermcp_hunyuan3d_intl_pro", False))
+            service = profile["service"]
+            action = profile["query_action"]
+            version = profile["version"]
+            region = profile["region"]
 
             headParams={
                 "Action": action,
@@ -3858,6 +3892,7 @@ class BLENDERMCP_PT_Panel(bpy.types.Panel):
                 else:
                     col.prop(scene, "blendermcp_hunyuan3d_secret_id", text="SecretId")
                     col.prop(scene, "blendermcp_hunyuan3d_secret_key", text="SecretKey")
+                col.prop(scene, "blendermcp_hunyuan3d_intl_pro", text="International (Pro) account")
             if scene.blendermcp_hunyuan3d_mode == 'LOCAL_API':
                 if prefs:
                     col.prop(prefs, "hunyuan3d_api_url", text="API URL")
@@ -4018,6 +4053,14 @@ def register():
         default="LOCAL_API"
     )
 
+    bpy.types.Scene.blendermcp_hunyuan3d_intl_pro = bpy.props.BoolProperty(
+        name="International (Pro)",
+        description="Use the Tencent Cloud International 'Hunyuan-to-3D (Professional)' service "
+                    "(hunyuan API, region ap-singapore, PBR enabled). Enable this when your SecretId/"
+                    "SecretKey come from tencentcloud.com; leave it off for mainland AI3D 3.0 accounts",
+        default=False
+    )
+
     bpy.types.Scene.blendermcp_hunyuan3d_secret_id = bpy.props.StringProperty(
         name="Hunyuan 3D SecretId",
         description="SecretId provided by Hunyuan 3D",
@@ -4150,6 +4193,7 @@ def unregister():
     del bpy.types.Scene.blendermcp_polypizza_api_key
     del bpy.types.Scene.blendermcp_use_hunyuan3d
     del bpy.types.Scene.blendermcp_hunyuan3d_mode
+    del bpy.types.Scene.blendermcp_hunyuan3d_intl_pro
     del bpy.types.Scene.blendermcp_hunyuan3d_secret_id
     del bpy.types.Scene.blendermcp_hunyuan3d_secret_key
     del bpy.types.Scene.blendermcp_hunyuan3d_api_url

--- a/tests/test_hunyuan_api_profile.py
+++ b/tests/test_hunyuan_api_profile.py
@@ -1,0 +1,182 @@
+"""Hunyuan3D OFFICIAL_API: the Tencent Cloud service must follow the account type.
+
+Mainland accounts use the AI3D 3.0 API; Tencent Cloud International accounts use the
+"Hunyuan-to-3D (Professional)" service, which lives on the older ``hunyuan`` API in
+``ap-singapore`` and takes ``EnablePBR`` instead of the mainland body fields. Sending
+International credentials to the mainland endpoint fails with AuthFailure.SignatureFailure.
+"""
+import importlib.util
+import json
+import sys
+import types
+
+from conftest import ROOT_ADDON as ADDON
+
+
+def _load_addon(monkeypatch, scene):
+    bpy = types.ModuleType("bpy")
+    bpy.context = types.SimpleNamespace(scene=scene)
+    bpy.types = types.SimpleNamespace(
+        AddonPreferences=object,
+        Operator=object,
+        Panel=object,
+        Scene=type("Scene", (), {}),
+    )
+
+    props = types.ModuleType("bpy.props")
+    for name in ("BoolProperty", "EnumProperty", "FloatProperty", "IntProperty", "StringProperty"):
+        setattr(props, name, lambda **_kwargs: None)
+    bpy.props = props
+
+    handlers = types.ModuleType("bpy.app.handlers")
+    handlers.persistent = lambda fn: fn
+    handlers.undo_post = []
+    handlers.redo_post = []
+    handlers.depsgraph_update_post = []
+
+    app = types.ModuleType("bpy.app")
+    app.version = (4, 2, 0)
+    app.version_string = "4.2.0"
+    app.background = False
+    app.handlers = handlers
+    app.timers = types.SimpleNamespace(
+        is_registered=lambda *_a, **_k: False,
+        register=lambda *_a, **_k: None,
+        unregister=lambda *_a, **_k: None,
+    )
+    bpy.app = app
+
+    monkeypatch.setitem(sys.modules, "bpy", bpy)
+    monkeypatch.setitem(sys.modules, "bpy.props", props)
+    monkeypatch.setitem(sys.modules, "bpy.app", app)
+    monkeypatch.setitem(sys.modules, "bpy.app.handlers", handlers)
+    monkeypatch.setitem(sys.modules, "mathutils", types.ModuleType("mathutils"))
+
+    requests = types.ModuleType("requests")
+    requests.utils = types.SimpleNamespace(default_headers=dict)
+    requests.exceptions = types.SimpleNamespace(Timeout=TimeoutError)
+    monkeypatch.setitem(sys.modules, "requests", requests)
+
+    spec = importlib.util.spec_from_file_location("blender_mcp_addon_test", ADDON)
+    addon = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(addon)
+    return addon
+
+
+def _scene(international_pro):
+    return types.SimpleNamespace(
+        blendermcp_use_polyhaven=False,
+        blendermcp_use_hyper3d=False,
+        blendermcp_use_sketchfab=False,
+        blendermcp_use_polypizza=False,
+        blendermcp_use_hunyuan3d=True,
+        blendermcp_hunyuan3d_mode="OFFICIAL_API",
+        blendermcp_hunyuan3d_intl_pro=international_pro,
+    )
+
+
+class _Response:
+    status_code = 200
+
+    @staticmethod
+    def json():
+        return {"Response": {"JobId": "job-1"}}
+
+
+def _capture_post(monkeypatch, addon):
+    calls = []
+
+    def fake_post(url, headers=None, data=None, **_kwargs):
+        calls.append({"url": url, "headers": headers or {}, "body": json.loads(data or "{}")})
+        return _Response()
+
+    monkeypatch.setattr(addon.requests, "post", fake_post, raising=False)
+    return calls
+
+
+def _server_with_credentials(monkeypatch, addon):
+    server = addon.BlenderMCPServer()
+    monkeypatch.setattr(server, "_get_hunyuan3d_secret_id", lambda: "AKIDtest")
+    monkeypatch.setattr(server, "_get_hunyuan3d_secret_key", lambda: "secret")
+    return server
+
+
+def test_profile_defaults_to_the_mainland_ai3d_service(monkeypatch):
+    addon = _load_addon(monkeypatch, _scene(False))
+    profile = addon.hunyuan_api_profile(False)
+    assert profile["service"] == "ai3d"
+    assert profile["version"] == "2025-05-13"
+    assert profile["region"] == "ap-guangzhou"
+    assert profile["submit_action"] == "SubmitHunyuanTo3DProJob"
+    assert profile["query_action"] == "QueryHunyuanTo3DProJob"
+    assert profile["submit_body"] == {}
+
+
+def test_profile_switches_to_the_international_pro_service(monkeypatch):
+    addon = _load_addon(monkeypatch, _scene(True))
+    profile = addon.hunyuan_api_profile(True)
+    assert profile["service"] == "hunyuan"
+    assert profile["version"] == "2023-09-01"
+    assert profile["region"] == "ap-singapore"
+    assert profile["submit_action"] == "SubmitHunyuanTo3DProJob"
+    assert profile["query_action"] == "QueryHunyuanTo3DProJob"
+    assert profile["submit_body"] == {"EnablePBR": True}
+
+
+def test_profile_returns_a_copy_so_callers_cannot_mutate_the_table(monkeypatch):
+    addon = _load_addon(monkeypatch, _scene(True))
+    addon.hunyuan_api_profile(True)["submit_body"]["Prompt"] = "leak"
+    assert addon.hunyuan_api_profile(True)["submit_body"] == {"EnablePBR": True}
+
+
+def test_submit_uses_the_mainland_endpoint_when_the_toggle_is_off(monkeypatch):
+    addon = _load_addon(monkeypatch, _scene(False))
+    server = _server_with_credentials(monkeypatch, addon)
+    calls = _capture_post(monkeypatch, addon)
+
+    assert server.create_hunyuan_job_main_site(text_prompt="a wooden stool") == {"Response": {"JobId": "job-1"}}
+
+    call = calls[0]
+    assert call["url"] == "https://ai3d.tencentcloudapi.com"
+    header_values = set(call["headers"].values())
+    assert {"SubmitHunyuanTo3DProJob", "2025-05-13", "ap-guangzhou"} <= header_values
+    assert call["body"] == {"Prompt": "a wooden stool"}
+
+
+def test_submit_uses_the_international_pro_endpoint_when_toggled(monkeypatch):
+    addon = _load_addon(monkeypatch, _scene(True))
+    server = _server_with_credentials(monkeypatch, addon)
+    calls = _capture_post(monkeypatch, addon)
+
+    server.create_hunyuan_job_main_site(text_prompt="a wooden stool")
+
+    call = calls[0]
+    assert call["url"] == "https://hunyuan.tencentcloudapi.com"
+    header_values = set(call["headers"].values())
+    assert {"SubmitHunyuanTo3DProJob", "2023-09-01", "ap-singapore"} <= header_values
+    assert call["body"] == {"EnablePBR": True, "Prompt": "a wooden stool"}
+
+
+def test_poll_uses_the_matching_query_profile(monkeypatch):
+    addon = _load_addon(monkeypatch, _scene(True))
+    server = _server_with_credentials(monkeypatch, addon)
+    calls = _capture_post(monkeypatch, addon)
+
+    server.poll_hunyuan_job_status_ai("job_abc")
+
+    call = calls[0]
+    assert call["url"] == "https://hunyuan.tencentcloudapi.com"
+    assert {"QueryHunyuanTo3DProJob", "2023-09-01", "ap-singapore"} <= set(call["headers"].values())
+    assert call["body"] == {"JobId": "abc"}
+
+
+def test_scene_without_the_toggle_behaves_like_mainland(monkeypatch):
+    scene = _scene(False)
+    del scene.blendermcp_hunyuan3d_intl_pro
+    addon = _load_addon(monkeypatch, scene)
+    server = _server_with_credentials(monkeypatch, addon)
+    calls = _capture_post(monkeypatch, addon)
+
+    server.poll_hunyuan_job_status_ai("job_abc")
+
+    assert calls[0]["url"] == "https://ai3d.tencentcloudapi.com"


### PR DESCRIPTION
## Why

Tencent Cloud exposes Hunyuan-to-3D through **two different services**, and which one an account can use depends on where the account was created:

| Account | Service | Version | Region | Body |
|---|---|---|---|---|
| Mainland (cloud.tencent.com) | `ai3d` (AI3D 3.0) | `2025-05-13` | `ap-guangzhou` | `{}` |
| Tencent Cloud International (tencentcloud.com), *Hunyuan-to-3D (Professional)* | `hunyuan` | `2023-09-01` | `ap-singapore` | `{"EnablePBR": true}` |

Since #294 the addon hard-codes the mainland AI3D 3.0 endpoint. International-site credentials sent there fail with `AuthFailure.SignatureFailure` / `ResourceUnavailable` (`计费状态未知`) — the symptom reported in #340 and, before the 3.0 update, #274. Both actions are still `SubmitHunyuanTo3DProJob` / `QueryHunyuanTo3DProJob`, so the only differences are service, version, region and the request body — see the International docs for [SubmitHunyuanTo3DProJob](https://www.tencentcloud.com/document/product/1284/75540).

## What

- **`hunyuan_api_profile(international_pro)`** + `HUNYUAN_API_PROFILES` table in `addon.py`: one place that decides service / version / region / actions / submit body, used by both `create_hunyuan_job_main_site` and `poll_hunyuan_job_status_ai`, so submit and query can never disagree.
- **"International (Pro) account"** checkbox under *Tencent Hunyuan 3D → Official API* in the sidebar (`blendermcp_hunyuan3d_intl_pro`, default off → behaviour identical to today).
- README: a short table explaining which toggle to use for which account.
- `src/blender_mcp/bundled/addon.py` kept in sync (the bundled-copy test passes).

## Tests

`tests/test_hunyuan_api_profile.py` (7 tests, same fake-`bpy` loader as `test_sketchfab_status.py`):
- profile table for both account types, and that callers get a copy;
- the actual `requests.post` made by submit and poll for both toggle states — endpoint host (`ai3d.` vs `hunyuan.tencentcloudapi.com`), `X-TC-Action` / `X-TC-Version` / `X-TC-Region` headers, and the JSON body (`EnablePBR` only for International);
- a scene without the property still behaves like mainland.

Full suite: 120 passed.

## Notes

- Default off, so mainland users see no change. Refs #340, #274.
- The mesh-texturing feature from the same fork is a separate PR (independent change).
