### PR TITLE
feat: texture an existing mesh with a local Hunyuan3D-2 server

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,22 @@ Once the config file has been set on Claude, and the addon is running on Blender
 - Search and download models from [Sketchfab](https://sketchfab.com/)
 - Search and download low-poly models from [Poly Pizza](https://poly.pizza/)
 - AI generated 3D models through [Hyper3D Rodin](https://hyper3d.ai/) and [Hunyuan3D](https://3d.hunyuan.tencent.com/)
+- Texture an existing mesh with a local [Hunyuan3D-2](https://github.com/Tencent/Hunyuan3D-2) server (`texture_mesh_hunyuan3d`)
+
+#### Texturing an existing mesh with Hunyuan3D (local API mode)
+
+With **Tencent Hunyuan 3D** enabled and its mode set to **local api** (a local
+[Hunyuan3D-2](https://github.com/Tencent/Hunyuan3D-2) API server running, default
+`http://localhost:8081`), Claude can paint a texture onto a mesh that is already in the scene
+instead of generating a new one:
+
+> *"Texture the object named Chair as weathered oak"*
+
+Claude calls `texture_mesh_hunyuan3d(object_name="Chair", text_prompt="weathered oak")`. The addon
+exports that mesh, sends it to the local server with the prompt (and/or a reference image via
+`input_image_url`), imports the textured result at the original object's transform and hides the
+original. This mirrors *Texture Selected Mesh* in the official Hunyuan3D-2 Blender addon and is not
+available with the cloud Official API.
 
 #### Poly Pizza
 

--- a/addon.py
+++ b/addon.py
@@ -818,7 +818,8 @@ class BlenderMCPServer:
             hunyuan_handlers = {
                 "create_hunyuan_job": self.create_hunyuan_job,
                 "poll_hunyuan_job_status": self.poll_hunyuan_job_status,
-                "import_generated_asset_hunyuan": self.import_generated_asset_hunyuan
+                "import_generated_asset_hunyuan": self.import_generated_asset_hunyuan,
+                "texture_hunyuan_mesh": self.texture_hunyuan_job_local,
             }
             handlers.update(hunyuan_handlers)
 
@@ -3534,6 +3535,111 @@ class BlenderMCPServer:
             return {"error": str(e)}
         
     
+    def texture_hunyuan_job_local(
+        self,
+        object_name: str,
+        text_prompt: str = None,
+        image: str = None):
+        """Texture an existing mesh through the local Hunyuan3D-2 API.
+
+        Exports the named mesh as a GLB, sends it (base64) together with a text
+        prompt and/or reference image to the local /generate endpoint with
+        texture=True, then imports the textured result on a Blender timer,
+        matching the original object's transform and hiding the original.
+        Only valid in LOCAL_API mode (the cloud API does not accept a mesh).
+        """
+        try:
+            base_url = self._get_hunyuan3d_api_url().rstrip('/')
+            if not base_url:
+                return {"error": "API URL is not given"}
+
+            obj = bpy.data.objects.get(object_name)
+            if obj is None or obj.type != 'MESH':
+                return {"error": f"Mesh object '{object_name}' not found"}
+
+            octree_resolution = bpy.context.scene.blendermcp_hunyuan3d_octree_resolution
+            num_inference_steps = bpy.context.scene.blendermcp_hunyuan3d_num_inference_steps
+            guidance_scale = bpy.context.scene.blendermcp_hunyuan3d_guidance_scale
+
+            # Export the mesh to a temporary GLB and base64-encode it
+            with tempfile.NamedTemporaryFile(delete=False, suffix=".glb") as tf_in:
+                tmp_in = tf_in.name
+            try:
+                bpy.ops.object.select_all(action='DESELECT')
+                obj.select_set(True)
+                bpy.context.view_layer.objects.active = obj
+                bpy.ops.export_scene.gltf(filepath=tmp_in, use_selection=True)
+                with open(tmp_in, "rb") as f:
+                    mesh_b64 = base64.b64encode(f.read()).decode()
+            finally:
+                if os.path.exists(tmp_in):
+                    os.unlink(tmp_in)
+
+            data = {
+                "mesh": mesh_b64,
+                "octree_resolution": octree_resolution,
+                "num_inference_steps": num_inference_steps,
+                "guidance_scale": guidance_scale,
+                "texture": True,
+            }
+            if text_prompt:
+                data["text"] = text_prompt
+            if image:
+                if re.match(r'^https?://', image, re.IGNORECASE) is not None:
+                    try:
+                        res_img = requests.get(image)
+                        res_img.raise_for_status()
+                        data["image"] = base64.b64encode(res_img.content).decode("ascii")
+                    except Exception as e:
+                        return {"error": f"Failed to download or encode image: {str(e)}"}
+                else:
+                    try:
+                        with open(image, "rb") as f:
+                            data["image"] = base64.b64encode(f.read()).decode("ascii")
+                    except Exception as e:
+                        return {"error": f"Image encoding failed: {str(e)}"}
+
+            response = requests.post(f"{base_url}/generate", json=data)
+            if response.status_code != 200:
+                return {"error": f"Texturing failed: {response.text}"}
+
+            with tempfile.NamedTemporaryFile(delete=False, suffix=".glb") as temp_file:
+                temp_file.write(response.content)
+                temp_out = temp_file.name
+
+            # Capture the original transform to apply to the textured result
+            src_loc = tuple(obj.location)
+            src_rot = tuple(obj.rotation_euler)
+            src_scl = tuple(obj.scale)
+
+            def import_handler():
+                before = set(bpy.data.objects)
+                bpy.ops.import_scene.gltf(filepath=temp_out)
+                if os.path.exists(temp_out):
+                    os.unlink(temp_out)
+                news = [o for o in bpy.data.objects if o not in before]
+                roots = [o for o in news if o.parent is None] or news
+                if roots:
+                    r0 = roots[0]
+                    r0.location = src_loc
+                    r0.rotation_euler = src_rot
+                    r0.scale = src_scl
+                src = bpy.data.objects.get(object_name)
+                if src is not None:
+                    src.hide_set(True)
+                    src.hide_render = True
+                return None
+
+            bpy.app.timers.register(import_handler)
+
+            return {
+                "status": "DONE",
+                "message": f"Textured mesh '{object_name}' and imported the result"
+            }
+        except Exception as e:
+            print(f"An error occurred: {e}")
+            return {"error": str(e)}
+
     def poll_hunyuan_job_status(self, *args, **kwargs):
         return self.poll_hunyuan_job_status_ai(*args, **kwargs)
     

--- a/src/blender_mcp/bundled/addon.py
+++ b/src/blender_mcp/bundled/addon.py
@@ -818,7 +818,8 @@ class BlenderMCPServer:
             hunyuan_handlers = {
                 "create_hunyuan_job": self.create_hunyuan_job,
                 "poll_hunyuan_job_status": self.poll_hunyuan_job_status,
-                "import_generated_asset_hunyuan": self.import_generated_asset_hunyuan
+                "import_generated_asset_hunyuan": self.import_generated_asset_hunyuan,
+                "texture_hunyuan_mesh": self.texture_hunyuan_job_local,
             }
             handlers.update(hunyuan_handlers)
 
@@ -3534,6 +3535,111 @@ class BlenderMCPServer:
             return {"error": str(e)}
         
     
+    def texture_hunyuan_job_local(
+        self,
+        object_name: str,
+        text_prompt: str = None,
+        image: str = None):
+        """Texture an existing mesh through the local Hunyuan3D-2 API.
+
+        Exports the named mesh as a GLB, sends it (base64) together with a text
+        prompt and/or reference image to the local /generate endpoint with
+        texture=True, then imports the textured result on a Blender timer,
+        matching the original object's transform and hiding the original.
+        Only valid in LOCAL_API mode (the cloud API does not accept a mesh).
+        """
+        try:
+            base_url = self._get_hunyuan3d_api_url().rstrip('/')
+            if not base_url:
+                return {"error": "API URL is not given"}
+
+            obj = bpy.data.objects.get(object_name)
+            if obj is None or obj.type != 'MESH':
+                return {"error": f"Mesh object '{object_name}' not found"}
+
+            octree_resolution = bpy.context.scene.blendermcp_hunyuan3d_octree_resolution
+            num_inference_steps = bpy.context.scene.blendermcp_hunyuan3d_num_inference_steps
+            guidance_scale = bpy.context.scene.blendermcp_hunyuan3d_guidance_scale
+
+            # Export the mesh to a temporary GLB and base64-encode it
+            with tempfile.NamedTemporaryFile(delete=False, suffix=".glb") as tf_in:
+                tmp_in = tf_in.name
+            try:
+                bpy.ops.object.select_all(action='DESELECT')
+                obj.select_set(True)
+                bpy.context.view_layer.objects.active = obj
+                bpy.ops.export_scene.gltf(filepath=tmp_in, use_selection=True)
+                with open(tmp_in, "rb") as f:
+                    mesh_b64 = base64.b64encode(f.read()).decode()
+            finally:
+                if os.path.exists(tmp_in):
+                    os.unlink(tmp_in)
+
+            data = {
+                "mesh": mesh_b64,
+                "octree_resolution": octree_resolution,
+                "num_inference_steps": num_inference_steps,
+                "guidance_scale": guidance_scale,
+                "texture": True,
+            }
+            if text_prompt:
+                data["text"] = text_prompt
+            if image:
+                if re.match(r'^https?://', image, re.IGNORECASE) is not None:
+                    try:
+                        res_img = requests.get(image)
+                        res_img.raise_for_status()
+                        data["image"] = base64.b64encode(res_img.content).decode("ascii")
+                    except Exception as e:
+                        return {"error": f"Failed to download or encode image: {str(e)}"}
+                else:
+                    try:
+                        with open(image, "rb") as f:
+                            data["image"] = base64.b64encode(f.read()).decode("ascii")
+                    except Exception as e:
+                        return {"error": f"Image encoding failed: {str(e)}"}
+
+            response = requests.post(f"{base_url}/generate", json=data)
+            if response.status_code != 200:
+                return {"error": f"Texturing failed: {response.text}"}
+
+            with tempfile.NamedTemporaryFile(delete=False, suffix=".glb") as temp_file:
+                temp_file.write(response.content)
+                temp_out = temp_file.name
+
+            # Capture the original transform to apply to the textured result
+            src_loc = tuple(obj.location)
+            src_rot = tuple(obj.rotation_euler)
+            src_scl = tuple(obj.scale)
+
+            def import_handler():
+                before = set(bpy.data.objects)
+                bpy.ops.import_scene.gltf(filepath=temp_out)
+                if os.path.exists(temp_out):
+                    os.unlink(temp_out)
+                news = [o for o in bpy.data.objects if o not in before]
+                roots = [o for o in news if o.parent is None] or news
+                if roots:
+                    r0 = roots[0]
+                    r0.location = src_loc
+                    r0.rotation_euler = src_rot
+                    r0.scale = src_scl
+                src = bpy.data.objects.get(object_name)
+                if src is not None:
+                    src.hide_set(True)
+                    src.hide_render = True
+                return None
+
+            bpy.app.timers.register(import_handler)
+
+            return {
+                "status": "DONE",
+                "message": f"Textured mesh '{object_name}' and imported the result"
+            }
+        except Exception as e:
+            print(f"An error occurred: {e}")
+            return {"error": str(e)}
+
     def poll_hunyuan_job_status(self, *args, **kwargs):
         return self.poll_hunyuan_job_status_ai(*args, **kwargs)
     

--- a/src/blender_mcp/server.py
+++ b/src/blender_mcp/server.py
@@ -1631,6 +1631,50 @@ async def import_generated_asset_hunyuan(
 
 
 @mcp.tool()
+@trajectory_tool("texture_mesh_hunyuan3d")
+async def texture_mesh_hunyuan3d(
+    ctx: Context,
+    object_name: str,
+    text_prompt: str = None,
+    input_image_url: str = None,
+    user_prompt: str = "",
+) -> str:
+    """
+    Texture an EXISTING mesh in the scene using Hunyuan3D (LOCAL_API mode only).
+
+    Sends the named mesh together with a text prompt and/or reference image to the
+    local Hunyuan3D-2 server, which paints a texture onto the mesh and returns a
+    textured GLB. The result is imported, aligned to the original object's transform,
+    and the original is hidden. This mirrors the "Texture Selected Mesh" feature of
+    the official Hunyuan3D-2 Blender addon.
+
+    Requirements:
+    - Hunyuan3D must be enabled and its mode set to "LOCAL_API" (a local
+      Hunyuan3D-2 API server must be running, default http://localhost:8081).
+    - The cloud OFFICIAL_API mode does not support mesh texturing.
+
+    Parameters:
+    - object_name: Name of the existing mesh object in the scene to texture.
+    - text_prompt: (Optional) Short description guiding the texture.
+    - input_image_url: (Optional) Local path or remote URL of a reference image.
+    - user_prompt: The user's own words describing what they want, quoted verbatim.
+
+    Returns a status message; on success status is "DONE" and the textured mesh is imported.
+    """
+    try:
+        blender = get_blender_connection()
+        result = blender.send_command("texture_hunyuan_mesh", {
+            "object_name": object_name,
+            "text_prompt": text_prompt,
+            "image": input_image_url,
+        })
+        return json.dumps(result) if isinstance(result, dict) else result
+    except Exception as e:
+        logger.error(f"Error texturing mesh with Hunyuan3D: {str(e)}")
+        return f"Error texturing mesh with Hunyuan3D: {str(e)}"
+
+
+@mcp.tool()
 def record_trajectory_feedback(
     ctx: Context,
     feedback: str,

--- a/tests/test_hunyuan_texture_mesh.py
+++ b/tests/test_hunyuan_texture_mesh.py
@@ -1,0 +1,232 @@
+"""Texturing an existing mesh through a local Hunyuan3D-2 server (LOCAL_API mode).
+
+The addon exports the named mesh to GLB, posts it base64-encoded with texture=True to the
+local /generate endpoint, and defers the import of the textured result to a Blender timer.
+"""
+import asyncio
+import base64
+import importlib.util
+import os
+import sys
+import types
+
+from conftest import ROOT_ADDON as ADDON
+
+
+class _Object:
+    def __init__(self, name, obj_type="MESH"):
+        self.name = name
+        self.type = obj_type
+        self.parent = None
+        self.location = (1.0, 2.0, 3.0)
+        self.rotation_euler = (0.0, 0.5, 0.0)
+        self.scale = (2.0, 2.0, 2.0)
+        self.selected = False
+
+    def select_set(self, value):
+        self.selected = value
+
+
+class _Objects:
+    def __init__(self, *objects):
+        self._by_name = {o.name: o for o in objects}
+
+    def get(self, name):
+        return self._by_name.get(name)
+
+    def __iter__(self):
+        return iter(list(self._by_name.values()))
+
+
+def _load_addon(monkeypatch, scene, objects, exported, timers):
+    bpy = types.ModuleType("bpy")
+    bpy.context = types.SimpleNamespace(
+        scene=scene,
+        view_layer=types.SimpleNamespace(objects=types.SimpleNamespace(active=None)),
+    )
+    bpy.data = types.SimpleNamespace(objects=objects)
+    bpy.types = types.SimpleNamespace(
+        AddonPreferences=object,
+        Operator=object,
+        Panel=object,
+        Scene=type("Scene", (), {}),
+    )
+
+    def export_gltf(filepath, use_selection=False, **_kwargs):
+        exported.append({"filepath": filepath, "use_selection": use_selection})
+        with open(filepath, "wb") as fh:
+            fh.write(b"GLBDATA")
+
+    bpy.ops = types.SimpleNamespace(
+        object=types.SimpleNamespace(select_all=lambda action: None),
+        export_scene=types.SimpleNamespace(gltf=export_gltf),
+    )
+
+    props = types.ModuleType("bpy.props")
+    for name in ("BoolProperty", "EnumProperty", "FloatProperty", "IntProperty", "StringProperty"):
+        setattr(props, name, lambda **_kwargs: None)
+    bpy.props = props
+
+    handlers = types.ModuleType("bpy.app.handlers")
+    handlers.persistent = lambda fn: fn
+    handlers.undo_post = []
+    handlers.redo_post = []
+    handlers.depsgraph_update_post = []
+
+    app = types.ModuleType("bpy.app")
+    app.version = (4, 2, 0)
+    app.version_string = "4.2.0"
+    app.background = False
+    app.handlers = handlers
+    app.timers = types.SimpleNamespace(
+        is_registered=lambda *_a, **_k: False,
+        register=lambda fn, *_a, **_k: timers.append(fn),
+        unregister=lambda *_a, **_k: None,
+    )
+    bpy.app = app
+
+    monkeypatch.setitem(sys.modules, "bpy", bpy)
+    monkeypatch.setitem(sys.modules, "bpy.props", props)
+    monkeypatch.setitem(sys.modules, "bpy.app", app)
+    monkeypatch.setitem(sys.modules, "bpy.app.handlers", handlers)
+    monkeypatch.setitem(sys.modules, "mathutils", types.ModuleType("mathutils"))
+
+    requests = types.ModuleType("requests")
+    requests.utils = types.SimpleNamespace(default_headers=dict)
+    requests.exceptions = types.SimpleNamespace(Timeout=TimeoutError)
+    monkeypatch.setitem(sys.modules, "requests", requests)
+
+    spec = importlib.util.spec_from_file_location("blender_mcp_addon_test", ADDON)
+    addon = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(addon)
+    return addon
+
+
+def _scene(hunyuan_enabled=True):
+    return types.SimpleNamespace(
+        blendermcp_use_polyhaven=False,
+        blendermcp_use_hyper3d=False,
+        blendermcp_use_sketchfab=False,
+        blendermcp_use_polypizza=False,
+        blendermcp_use_hunyuan3d=hunyuan_enabled,
+        blendermcp_hunyuan3d_mode="LOCAL_API",
+        blendermcp_hunyuan3d_octree_resolution=256,
+        blendermcp_hunyuan3d_num_inference_steps=20,
+        blendermcp_hunyuan3d_guidance_scale=5.5,
+    )
+
+
+class _Response:
+    def __init__(self, status_code=200, content=b"TEXTURED-GLB", text=""):
+        self.status_code = status_code
+        self.content = content
+        self.text = text
+
+
+def _capture_post(monkeypatch, addon, response=None):
+    calls = []
+
+    def fake_post(url, json=None, **_kwargs):
+        calls.append({"url": url, "json": json})
+        return response or _Response()
+
+    monkeypatch.setattr(addon.requests, "post", fake_post, raising=False)
+    return calls
+
+
+def _server(monkeypatch, addon):
+    server = addon.BlenderMCPServer()
+    monkeypatch.setattr(server, "_get_hunyuan3d_api_url", lambda: "http://localhost:8081/")
+    return server
+
+
+def test_texturing_posts_the_exported_mesh_to_the_local_server(monkeypatch):
+    exported, timers = [], []
+    cube = _Object("Cube")
+    addon = _load_addon(monkeypatch, _scene(), _Objects(cube), exported, timers)
+    server = _server(monkeypatch, addon)
+    calls = _capture_post(monkeypatch, addon)
+
+    result = server.texture_hunyuan_job_local("Cube", text_prompt="weathered oak")
+
+    assert result["status"] == "DONE"
+    assert exported[0]["use_selection"] is True
+    assert cube.selected is True
+    assert not os.path.exists(exported[0]["filepath"]), "temporary export must be cleaned up"
+
+    call = calls[0]
+    assert call["url"] == "http://localhost:8081/generate"
+    payload = call["json"]
+    assert payload["mesh"] == base64.b64encode(b"GLBDATA").decode()
+    assert payload["texture"] is True
+    assert payload["text"] == "weathered oak"
+    assert payload["octree_resolution"] == 256
+    assert payload["num_inference_steps"] == 20
+    assert payload["guidance_scale"] == 5.5
+    assert "image" not in payload
+    assert len(timers) == 1, "the textured result is imported on a Blender timer"
+
+
+def test_reference_image_file_is_base64_encoded(monkeypatch, tmp_path):
+    image = tmp_path / "ref.png"
+    image.write_bytes(b"PNGDATA")
+    addon = _load_addon(monkeypatch, _scene(), _Objects(_Object("Cube")), [], [])
+    server = _server(monkeypatch, addon)
+    calls = _capture_post(monkeypatch, addon)
+
+    server.texture_hunyuan_job_local("Cube", image=str(image))
+
+    assert calls[0]["json"]["image"] == base64.b64encode(b"PNGDATA").decode("ascii")
+
+
+def test_missing_or_non_mesh_object_is_rejected_before_any_request(monkeypatch):
+    addon = _load_addon(monkeypatch, _scene(), _Objects(_Object("Lamp", obj_type="LIGHT")), [], [])
+    server = _server(monkeypatch, addon)
+    calls = _capture_post(monkeypatch, addon)
+
+    assert "not found" in server.texture_hunyuan_job_local("Nope")["error"]
+    assert "not found" in server.texture_hunyuan_job_local("Lamp")["error"]
+    assert calls == []
+
+
+def test_server_error_is_reported_without_importing(monkeypatch):
+    timers = []
+    addon = _load_addon(monkeypatch, _scene(), _Objects(_Object("Cube")), [], timers)
+    server = _server(monkeypatch, addon)
+    _capture_post(monkeypatch, addon, response=_Response(status_code=500, text="boom"))
+
+    result = server.texture_hunyuan_job_local("Cube", text_prompt="x")
+
+    assert "boom" in result["error"]
+    assert timers == []
+
+
+def test_command_is_only_routed_when_hunyuan_is_enabled(monkeypatch):
+    addon = _load_addon(monkeypatch, _scene(hunyuan_enabled=False), _Objects(), [], [])
+    server = addon.BlenderMCPServer()
+
+    command = server._execute_command_internal({"type": "texture_hunyuan_mesh", "params": {"object_name": "Cube"}})
+
+    assert command == {"status": "error", "message": "Unknown command type: texture_hunyuan_mesh"}
+
+
+def test_mcp_tool_forwards_the_command_to_blender():
+    from blender_mcp import server
+
+    sent = []
+
+    class FakeBlender:
+        def send_command(self, command, params=None):
+            sent.append((command, params))
+            return {"status": "DONE", "message": "ok"}
+
+    original = server.get_blender_connection
+    server.get_blender_connection = lambda: FakeBlender()
+    try:
+        out = asyncio.run(server.texture_mesh_hunyuan3d(
+            None, object_name="Cube", text_prompt="oak", input_image_url=None, user_prompt=""))
+    finally:
+        server.get_blender_connection = original
+
+    assert sent == [("texture_hunyuan_mesh", {"object_name": "Cube", "text_prompt": "oak", "image": None})]
+    assert "DONE" in out


### PR DESCRIPTION
## Why

In `LOCAL_API` mode the addon can generate a *new* model with a local [Hunyuan3D-2](https://github.com/Tencent/Hunyuan3D-2) server, but it cannot texture a mesh that is already in the scene — the official Hunyuan3D-2 Blender addon has this as *Texture Selected Mesh*, and it is the more common request once a model exists ("make this chair weathered oak"). Regenerating from scratch loses the geometry the user already has.

## What

- **`texture_mesh_hunyuan3d(object_name, text_prompt?, input_image_url?)`** MCP tool (`server.py`, `async`, `@trajectory_tool` like the sibling Hunyuan tools).
- **`texture_hunyuan_job_local`** handler in `addon.py`, registered only while Hunyuan3D is enabled: exports the named mesh as GLB, posts it base64-encoded with `texture=True` (plus prompt and/or reference image, and the existing octree / steps / guidance settings) to `<api url>/generate`, writes the textured GLB to a temp file and imports it on a `bpy.app.timers` callback at the original object's transform, then hides the original.
- README: capability bullet and a short how-to under the sidebar section.
- `src/blender_mcp/bundled/addon.py` kept in sync.

`LOCAL_API` only — the cloud Official API does not accept a mesh input; the tool docstring says so.

## Tests

`tests/test_hunyuan_texture_mesh.py` (6 tests, fake `bpy` with `data.objects` / `ops.export_scene.gltf` / `app.timers`):
- the request payload (base64 of the exported GLB, `texture: true`, prompt, generation settings) and that the temp export is cleaned up and the import is deferred to a timer;
- a reference image file is base64-encoded;
- missing / non-mesh objects are rejected before any request;
- a non-200 response is reported and nothing is imported;
- the command is not routed while Hunyuan3D is disabled;
- the MCP tool boundary forwards `texture_hunyuan_mesh` with the expected params.

Full suite: 119 passed.

## Notes

Independent of the International (Pro) account PR from the same fork; either can land first.
