### PR TITLE
feat: export_scene command and MCP tool (GLB/FBX to a caller-chosen path)

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,6 +445,7 @@ Once the config file has been set on Claude, and the addon is running on Blender
 - Create, delete and modify shapes
 - Apply or create materials for objects
 - Execute any Python code in Blender
+- Export the scene, the selection or named objects to GLB/FBX for other applications (`export_scene`)
 - Download the right models, assets and HDRIs through [Poly Haven](https://polyhaven.com/)
 - Search and download models from [Sketchfab](https://sketchfab.com/)
 - Search and download low-poly models from [Poly Pizza](https://poly.pizza/)

--- a/addon.py
+++ b/addon.py
@@ -775,6 +775,7 @@ class BlenderMCPServer:
             "get_sketchfab_status": self.get_sketchfab_status,
             "get_polypizza_status": self.get_polypizza_status,
             "get_hunyuan3d_status": self.get_hunyuan3d_status,
+            "export_scene": self.export_scene,
         }
 
         # Add Polyhaven handlers only if enabled
@@ -1382,6 +1383,74 @@ class BlenderMCPServer:
             raise Exception(f"Code execution error: {str(e)}")
 
 
+
+    def export_scene(self, filepath, format="glb", object_names=None, selection_only=False, apply_modifiers=True):
+        """Export the whole scene, the current selection, or the named objects to a GLB or FBX file.
+
+        Named objects are exported together with their children. GLB carries PBR
+        materials, emission, skins, shape keys and animation; FBX is the fallback for
+        tools that need Unity's built-in importer. apply_modifiers=False keeps rigs
+        and shape keys intact. The file is written where the caller asked, so other
+        applications (game engines, viewers) can pick it up without going through
+        execute_code.
+        """
+        if not filepath:
+            return {"error": "filepath is required"}
+        fmt = (format or "glb").lower()
+        if fmt not in ("glb", "fbx"):
+            return {"error": f"format must be glb or fbx, got '{format}'"}
+
+        names = [n for n in (object_names or []) if n]
+        use_selection = False
+        exported = []
+        if names:
+            missing = [n for n in names if bpy.data.objects.get(n) is None]
+            if missing:
+                return {"error": "Objects not found in Blender: " + ", ".join(missing)}
+            bpy.ops.object.select_all(action='DESELECT')
+            for n in names:
+                obj = bpy.data.objects[n]
+                for o in [obj, *obj.children_recursive]:
+                    o.select_set(True)
+                    if o.name not in exported:
+                        exported.append(o.name)
+            bpy.context.view_layer.objects.active = bpy.data.objects[names[0]]
+            use_selection = True
+        elif selection_only:
+            if not bpy.context.selected_objects:
+                return {"error": "Nothing is selected in Blender and no object_names were given"}
+            exported = [o.name for o in bpy.context.selected_objects]
+            use_selection = True
+        else:
+            exported = [o.name for o in bpy.context.scene.objects]
+
+        try:
+            if bpy.context.object and getattr(bpy.context.object, "mode", 'OBJECT') != 'OBJECT':
+                bpy.ops.object.mode_set(mode='OBJECT')
+        except Exception:
+            pass
+
+        directory = os.path.dirname(filepath)
+        if directory:
+            os.makedirs(directory, exist_ok=True)
+
+        if fmt == "glb":
+            bpy.ops.export_scene.gltf(
+                filepath=filepath, export_format='GLB', use_selection=use_selection,
+                use_active_scene=True, export_apply=apply_modifiers,
+                export_animations=True, export_skins=True, export_morph=True, export_yup=True)
+        else:
+            bpy.ops.export_scene.fbx(
+                filepath=filepath, use_selection=use_selection, apply_unit_scale=True,
+                bake_space_transform=apply_modifiers, use_mesh_modifiers=apply_modifiers,
+                path_mode='COPY', embed_textures=True)
+
+        return {
+            "path": filepath,
+            "bytes": os.path.getsize(filepath),
+            "selection_only": use_selection,
+            "exported": exported,
+        }
 
     def get_polyhaven_categories(self, asset_type):
         """Get categories for a specific asset type from Polyhaven"""

--- a/src/blender_mcp/bundled/addon.py
+++ b/src/blender_mcp/bundled/addon.py
@@ -775,6 +775,7 @@ class BlenderMCPServer:
             "get_sketchfab_status": self.get_sketchfab_status,
             "get_polypizza_status": self.get_polypizza_status,
             "get_hunyuan3d_status": self.get_hunyuan3d_status,
+            "export_scene": self.export_scene,
         }
 
         # Add Polyhaven handlers only if enabled
@@ -1382,6 +1383,74 @@ class BlenderMCPServer:
             raise Exception(f"Code execution error: {str(e)}")
 
 
+
+    def export_scene(self, filepath, format="glb", object_names=None, selection_only=False, apply_modifiers=True):
+        """Export the whole scene, the current selection, or the named objects to a GLB or FBX file.
+
+        Named objects are exported together with their children. GLB carries PBR
+        materials, emission, skins, shape keys and animation; FBX is the fallback for
+        tools that need Unity's built-in importer. apply_modifiers=False keeps rigs
+        and shape keys intact. The file is written where the caller asked, so other
+        applications (game engines, viewers) can pick it up without going through
+        execute_code.
+        """
+        if not filepath:
+            return {"error": "filepath is required"}
+        fmt = (format or "glb").lower()
+        if fmt not in ("glb", "fbx"):
+            return {"error": f"format must be glb or fbx, got '{format}'"}
+
+        names = [n for n in (object_names or []) if n]
+        use_selection = False
+        exported = []
+        if names:
+            missing = [n for n in names if bpy.data.objects.get(n) is None]
+            if missing:
+                return {"error": "Objects not found in Blender: " + ", ".join(missing)}
+            bpy.ops.object.select_all(action='DESELECT')
+            for n in names:
+                obj = bpy.data.objects[n]
+                for o in [obj, *obj.children_recursive]:
+                    o.select_set(True)
+                    if o.name not in exported:
+                        exported.append(o.name)
+            bpy.context.view_layer.objects.active = bpy.data.objects[names[0]]
+            use_selection = True
+        elif selection_only:
+            if not bpy.context.selected_objects:
+                return {"error": "Nothing is selected in Blender and no object_names were given"}
+            exported = [o.name for o in bpy.context.selected_objects]
+            use_selection = True
+        else:
+            exported = [o.name for o in bpy.context.scene.objects]
+
+        try:
+            if bpy.context.object and getattr(bpy.context.object, "mode", 'OBJECT') != 'OBJECT':
+                bpy.ops.object.mode_set(mode='OBJECT')
+        except Exception:
+            pass
+
+        directory = os.path.dirname(filepath)
+        if directory:
+            os.makedirs(directory, exist_ok=True)
+
+        if fmt == "glb":
+            bpy.ops.export_scene.gltf(
+                filepath=filepath, export_format='GLB', use_selection=use_selection,
+                use_active_scene=True, export_apply=apply_modifiers,
+                export_animations=True, export_skins=True, export_morph=True, export_yup=True)
+        else:
+            bpy.ops.export_scene.fbx(
+                filepath=filepath, use_selection=use_selection, apply_unit_scale=True,
+                bake_space_transform=apply_modifiers, use_mesh_modifiers=apply_modifiers,
+                path_mode='COPY', embed_textures=True)
+
+        return {
+            "path": filepath,
+            "bytes": os.path.getsize(filepath),
+            "selection_only": use_selection,
+            "exported": exported,
+        }
 
     def get_polyhaven_categories(self, asset_type):
         """Get categories for a specific asset type from Polyhaven"""

--- a/src/blender_mcp/server.py
+++ b/src/blender_mcp/server.py
@@ -1631,6 +1631,46 @@ async def import_generated_asset_hunyuan(
 
 
 @mcp.tool()
+@trajectory_tool("export_scene")
+async def export_scene(
+    ctx: Context,
+    filepath: str,
+    format: str = "glb",
+    object_names: list[str] = None,
+    selection_only: bool = False,
+    apply_modifiers: bool = True,
+    user_prompt: str = "",
+) -> str:
+    """
+    Export the whole scene, the current selection, or named objects to a GLB or FBX file on disk,
+    so another application (a game engine, a viewer, a converter) can pick it up.
+
+    Parameters:
+    - filepath: Absolute path of the file to write (.glb or .fbx). Parent folders are created.
+    - format: "glb" (default; keeps PBR materials, emission, skins, shape keys, animation) or "fbx".
+    - object_names: Export only these objects (children included). Omit for selection_only or the whole scene.
+    - selection_only: Export what is currently selected in Blender (ignored when object_names is given).
+    - apply_modifiers: Bake modifiers on export. Use false for rigged / shape-key meshes.
+    - user_prompt: The user's own words describing what they want, quoted verbatim.
+
+    Returns JSON with path, bytes, selection_only and the exported object names.
+    """
+    try:
+        blender = get_blender_connection()
+        result = blender.send_command("export_scene", {
+            "filepath": filepath,
+            "format": format,
+            "object_names": object_names,
+            "selection_only": selection_only,
+            "apply_modifiers": apply_modifiers,
+        })
+        return json.dumps(result) if isinstance(result, dict) else result
+    except Exception as e:
+        logger.error(f"Error exporting scene: {str(e)}")
+        return f"Error exporting scene: {str(e)}"
+
+
+@mcp.tool()
 def record_trajectory_feedback(
     ctx: Context,
     feedback: str,

--- a/tests/test_export_scene.py
+++ b/tests/test_export_scene.py
@@ -1,0 +1,207 @@
+"""export_scene: write the whole scene, the current selection, or named objects to GLB/FBX."""
+import asyncio
+import importlib.util
+import json
+import os
+import sys
+import types
+
+from conftest import ROOT_ADDON as ADDON
+
+
+class _Object:
+    def __init__(self, name, children=()):
+        self.name = name
+        self.children_recursive = list(children)
+        self.selected = False
+
+    def select_set(self, value):
+        self.selected = value
+
+
+class _Objects:
+    def __init__(self, *objects):
+        self._all = list(objects)
+        self._by_name = {o.name: o for o in objects}
+
+    def get(self, name):
+        return self._by_name.get(name)
+
+    def __getitem__(self, name):
+        return self._by_name[name]
+
+    def __iter__(self):
+        return iter(self._all)
+
+
+def _load_addon(monkeypatch, objects, selected, exports):
+    scene = types.SimpleNamespace(
+        blendermcp_use_polyhaven=False,
+        blendermcp_use_hyper3d=False,
+        blendermcp_use_sketchfab=False,
+        blendermcp_use_polypizza=False,
+        blendermcp_use_hunyuan3d=False,
+        objects=objects,
+    )
+    bpy = types.ModuleType("bpy")
+    bpy.context = types.SimpleNamespace(
+        scene=scene,
+        object=None,
+        selected_objects=selected,
+        view_layer=types.SimpleNamespace(objects=types.SimpleNamespace(active=None)),
+    )
+    bpy.data = types.SimpleNamespace(objects=objects)
+    bpy.types = types.SimpleNamespace(
+        AddonPreferences=object,
+        Operator=object,
+        Panel=object,
+        Scene=type("Scene", (), {}),
+    )
+
+    def export(kind):
+        def _op(filepath, **kwargs):
+            exports.append({"kind": kind, "filepath": filepath, **kwargs})
+            with open(filepath, "wb") as fh:
+                fh.write(b"EXPORTED")
+        return _op
+
+    bpy.ops = types.SimpleNamespace(
+        object=types.SimpleNamespace(select_all=lambda action: None, mode_set=lambda mode: None),
+        export_scene=types.SimpleNamespace(gltf=export("gltf"), fbx=export("fbx")),
+    )
+
+    props = types.ModuleType("bpy.props")
+    for name in ("BoolProperty", "EnumProperty", "FloatProperty", "IntProperty", "StringProperty"):
+        setattr(props, name, lambda **_kwargs: None)
+    bpy.props = props
+
+    handlers = types.ModuleType("bpy.app.handlers")
+    handlers.persistent = lambda fn: fn
+    handlers.undo_post = []
+    handlers.redo_post = []
+    handlers.depsgraph_update_post = []
+
+    app = types.ModuleType("bpy.app")
+    app.version = (4, 2, 0)
+    app.version_string = "4.2.0"
+    app.background = False
+    app.handlers = handlers
+    app.timers = types.SimpleNamespace(
+        is_registered=lambda *_a, **_k: False,
+        register=lambda *_a, **_k: None,
+        unregister=lambda *_a, **_k: None,
+    )
+    bpy.app = app
+
+    monkeypatch.setitem(sys.modules, "bpy", bpy)
+    monkeypatch.setitem(sys.modules, "bpy.props", props)
+    monkeypatch.setitem(sys.modules, "bpy.app", app)
+    monkeypatch.setitem(sys.modules, "bpy.app.handlers", handlers)
+    monkeypatch.setitem(sys.modules, "mathutils", types.ModuleType("mathutils"))
+
+    requests = types.ModuleType("requests")
+    requests.utils = types.SimpleNamespace(default_headers=dict)
+    requests.exceptions = types.SimpleNamespace(Timeout=TimeoutError)
+    monkeypatch.setitem(sys.modules, "requests", requests)
+
+    spec = importlib.util.spec_from_file_location("blender_mcp_addon_test", ADDON)
+    addon = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(addon)
+    return addon
+
+
+def test_named_objects_export_with_their_children_as_glb(monkeypatch, tmp_path):
+    leg = _Object("Leg")
+    chair = _Object("Chair", children=[leg])
+    lamp = _Object("Lamp")
+    exports = []
+    addon = _load_addon(monkeypatch, _Objects(chair, leg, lamp), [], exports)
+    out = str(tmp_path / "chair.glb")
+
+    result = addon.BlenderMCPServer().export_scene(out, object_names=["Chair"])
+
+    assert result == {"path": out, "bytes": len(b"EXPORTED"), "selection_only": True, "exported": ["Chair", "Leg"]}
+    assert chair.selected and leg.selected and not lamp.selected
+    assert exports[0]["kind"] == "gltf"
+    assert exports[0]["use_selection"] is True
+    assert exports[0]["use_active_scene"] is True
+    assert exports[0]["export_apply"] is True
+    assert exports[0]["export_format"] == "GLB"
+
+
+def test_selection_only_exports_the_current_selection_as_fbx(monkeypatch, tmp_path):
+    cube = _Object("Cube")
+    exports = []
+    addon = _load_addon(monkeypatch, _Objects(cube, _Object("Other")), [cube], exports)
+    out = str(tmp_path / "sel.fbx")
+
+    result = addon.BlenderMCPServer().export_scene(out, format="fbx", selection_only=True, apply_modifiers=False)
+
+    assert result["exported"] == ["Cube"]
+    assert result["selection_only"] is True
+    assert exports[0]["kind"] == "fbx"
+    assert exports[0]["use_selection"] is True
+    assert exports[0]["use_mesh_modifiers"] is False
+    assert exports[0]["bake_space_transform"] is False
+
+
+def test_whole_scene_when_nothing_is_named_or_selected(monkeypatch, tmp_path):
+    objs = _Objects(_Object("A"), _Object("B"))
+    exports = []
+    addon = _load_addon(monkeypatch, objs, [], exports)
+    out = str(tmp_path / "nested" / "scene.glb")
+
+    result = addon.BlenderMCPServer().export_scene(out)
+
+    assert result["selection_only"] is False
+    assert result["exported"] == ["A", "B"]
+    assert exports[0]["use_selection"] is False
+    assert os.path.isdir(str(tmp_path / "nested")), "parent folders are created"
+
+
+def test_missing_objects_and_bad_input_are_rejected_before_exporting(monkeypatch, tmp_path):
+    exports = []
+    addon = _load_addon(monkeypatch, _Objects(_Object("A")), [], exports)
+    server = addon.BlenderMCPServer()
+    out = str(tmp_path / "x.glb")
+
+    assert "not found" in server.export_scene(out, object_names=["A", "Ghost"])["error"]
+    assert "glb" in server.export_scene(out, format="obj")["error"]
+    assert "filepath" in server.export_scene("")["error"]
+    assert "Nothing is selected" in server.export_scene(out, selection_only=True)["error"]
+    assert exports == []
+
+
+def test_command_is_always_routed(monkeypatch, tmp_path):
+    exports = []
+    addon = _load_addon(monkeypatch, _Objects(_Object("A")), [], exports)
+    out = str(tmp_path / "scene.glb")
+
+    command = addon.BlenderMCPServer()._execute_command_internal({"type": "export_scene", "params": {"filepath": out}})
+
+    assert command["status"] == "success"
+    assert command["result"]["exported"] == ["A"]
+
+
+def test_mcp_tool_forwards_the_command_to_blender():
+    from blender_mcp import server
+
+    sent = []
+
+    class FakeBlender:
+        def send_command(self, command, params=None):
+            sent.append((command, params))
+            return {"path": "/tmp/x.glb", "bytes": 10, "selection_only": False, "exported": ["A"]}
+
+    original = server.get_blender_connection
+    server.get_blender_connection = lambda: FakeBlender()
+    try:
+        out = asyncio.run(server.export_scene(
+            None, filepath="/tmp/x.glb", format="glb", object_names=None, selection_only=False,
+            apply_modifiers=True, user_prompt=""))
+    finally:
+        server.get_blender_connection = original
+
+    assert sent == [("export_scene", {"filepath": "/tmp/x.glb", "format": "glb", "object_names": None,
+                                      "selection_only": False, "apply_modifiers": True})]
+    assert json.loads(out)["exported"] == ["A"]


### PR DESCRIPTION
## Why

Anything outside Blender that wants a model out of it — a game-engine bridge, a viewer, a converter — currently has to push an export script through `execute_blender_code` and hope it survives quoting and the safe-mode allowlist. That is fragile (every caller re-implements selection handling, modifier baking, GLB flags) and it is the kind of arbitrary code execution safe mode exists to discourage.

`export_scene` makes the common case a first-class, validated command: write the whole scene, the current selection, or named objects (children included) to a GLB or FBX file at a caller-chosen path.

## What

- **`export_scene(filepath, format="glb", object_names=None, selection_only=False, apply_modifiers=True)`** handler in `addon.py`, registered in the always-available base handlers (no integration toggle needed — it only touches the local scene and disk).
  - Validates `format` and `object_names` before selecting anything; creates parent folders.
  - GLB: `export_format='GLB'`, `use_active_scene=True` (the default `False` can silently export a different open scene), `export_apply=apply_modifiers`, animations / skins / morph targets on, Y-up.
  - FBX: `use_mesh_modifiers` and `bake_space_transform` follow `apply_modifiers`, `path_mode='COPY'` + `embed_textures=True`.
  - Returns `{path, bytes, selection_only, exported: [...]}`.
- **`export_scene`** MCP tool in `server.py` (`async`, `@trajectory_tool`, same shape as the other tools).
- README capability bullet.
- `src/blender_mcp/bundled/addon.py` kept in sync.

## Tests

`tests/test_export_scene.py` (6 tests, fake `bpy` with `data.objects`, `ops.export_scene.gltf/fbx`):
- named objects export with their children as GLB and the right glTF flags;
- selection-only FBX with modifiers kept;
- whole scene when nothing is named or selected, parent folder creation;
- missing objects / bad format / empty path / empty selection are rejected before any export;
- the command is routed without any integration enabled;
- the MCP tool forwards the exact params.

Full suite: 125 passed.

## Notes

No protocol version bump: callers that need the command can probe for it and fall back to `execute_blender_code` on older addons (that is what the Unity-side bridge in CoplayDev/unity-mcp#1375 does).
