### PR TITLE
fix: defer and retry Blender server auto-start

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -54,6 +54,91 @@ RODIN_FREE_TRIAL_KEY = "vibecoding"
 REQ_HEADERS = requests.utils.default_headers()
 REQ_HEADERS.update({"User-Agent": "blender-mcp"})
 
+# Set when the user disconnects so opening another blend file does not restart
+# the server behind their back. A manual connect or add-on reload clears it.
+_user_stopped_server = False
+
+
+def _blendermcp_port_has_listener(host, port):
+    """Return True when another process already owns the MCP endpoint."""
+    probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    probe.settimeout(0.15)
+    try:
+        return probe.connect_ex((host, port)) == 0
+    finally:
+        probe.close()
+
+
+def _blendermcp_ensure_server_running():
+    """Start the bridge after Blender's UI and scene context are ready.
+
+    Returning a delay asks Blender's timer system to retry when a launch-time
+    socket or context race prevented the first attempt.
+    """
+    if bpy.app.background:
+        return None
+
+    scene = getattr(bpy.context, "scene", None)
+    if scene is None:
+        return 0.5
+
+    server = getattr(bpy.types, "blendermcp_server", None)
+    if not scene.blendermcp_auto_start_server or _user_stopped_server:
+        scene.blendermcp_server_running = bool(server is not None and server.running)
+        return None
+
+    port = scene.blendermcp_port
+    if server is None:
+        if _blendermcp_port_has_listener("localhost", port):
+            scene.blendermcp_server_running = False
+            print(f"BlenderMCP: port {port} is already in use; auto-start skipped.")
+            return None
+        server = BlenderMCPServer(port=port)
+        bpy.types.blendermcp_server = server
+
+    if not server.running:
+        # Safe while stopped and necessary when a newly loaded scene selects a
+        # different port. Never retarget an active connection.
+        server.port = port
+        server.start()
+
+    scene.blendermcp_server_running = server.running
+
+    return None if server.running else 1.0
+
+
+def _blendermcp_schedule_auto_start(delay=0.5):
+    """Schedule one persistent startup callback if none is already pending."""
+    if not bpy.app.timers.is_registered(_blendermcp_ensure_server_running):
+        bpy.app.timers.register(
+            _blendermcp_ensure_server_running,
+            first_interval=delay,
+            persistent=True,
+        )
+
+
+@persistent
+def _blendermcp_load_post(_unused):
+    """Retry auto-start after Blender loads a startup file or another blend."""
+    _blendermcp_schedule_auto_start()
+
+
+def _blendermcp_register_auto_start():
+    """Install the load handler and defer the initial startup attempt."""
+    global _user_stopped_server
+    _user_stopped_server = False
+    if _blendermcp_load_post not in bpy.app.handlers.load_post:
+        bpy.app.handlers.load_post.append(_blendermcp_load_post)
+    _blendermcp_schedule_auto_start()
+
+
+def _blendermcp_unregister_auto_start():
+    """Remove callbacks owned by the add-on before it is disabled."""
+    if _blendermcp_load_post in bpy.app.handlers.load_post:
+        bpy.app.handlers.load_post.remove(_blendermcp_load_post)
+    if bpy.app.timers.is_registered(_blendermcp_ensure_server_running):
+        bpy.app.timers.unregister(_blendermcp_ensure_server_running)
+
 #region Poly Pizza constants and helpers
 
 POLYPIZZA_API_BASE = "https://api.poly.pizza/v1.1"
@@ -3798,7 +3883,9 @@ class BLENDERMCP_PT_Panel(bpy.types.Panel):
         box = layout.box()
         col = box.column()
         if scene.blendermcp_server_running:
-            col.label(text=f"Connected on port {scene.blendermcp_port}", icon='CHECKMARK')
+            server = getattr(bpy.types, "blendermcp_server", None)
+            running_port = getattr(server, "port", scene.blendermcp_port)
+            col.label(text=f"Connected on port {running_port}", icon='CHECKMARK')
             col.operator("blendermcp.stop_server", text="Disconnect", icon='X')
         else:
             col.label(text="Not connected", icon='RADIOBUT_OFF')
@@ -3904,6 +3991,8 @@ class BLENDERMCP_OT_StartServer(bpy.types.Operator):
     bl_description = "Start the MCP for Blender server to connect with Claude"
 
     def execute(self, context):
+        global _user_stopped_server
+        _user_stopped_server = False
         scene = context.scene
 
         # Create a new server instance
@@ -3923,6 +4012,8 @@ class BLENDERMCP_OT_StopServer(bpy.types.Operator):
     bl_description = "Stop the connection to Claude"
 
     def execute(self, context):
+        global _user_stopped_server
+        _user_stopped_server = True
         scene = context.scene
 
         # Stop the server if it exists
@@ -4102,27 +4193,15 @@ def register():
     bpy.utils.register_class(BLENDERMCP_OT_StopServer)
     bpy.utils.register_class(BLENDERMCP_OT_OpenTerms)
 
-    # Auto-start the server so the MCP client can connect without manual UI interaction
-    scene = getattr(bpy.context, 'scene', None)
-    if scene is not None:
-        port = scene.blendermcp_port
-        auto_start = scene.blendermcp_auto_start_server
-    else:
-        port = 9876
-        auto_start = True
-
-    if auto_start and (not hasattr(bpy.types, "blendermcp_server") or not bpy.types.blendermcp_server):
-        bpy.types.blendermcp_server = BlenderMCPServer(port=port)
-    if auto_start and not bpy.types.blendermcp_server.running:
-        bpy.types.blendermcp_server.start()
-        try:
-            bpy.context.scene.blendermcp_server_running = bpy.types.blendermcp_server.running
-        except AttributeError:
-            pass
+    # Add-on registration can run before Blender has a stable UI/scene context.
+    # Defer socket startup and retry after startup-file or .blend loads.
+    _blendermcp_register_auto_start()
 
     print("BlenderMCP addon registered")
 
 def unregister():
+    _blendermcp_unregister_auto_start()
+
     _unregister_edit_capture_handlers()
 
     # Stop the server if it's running

--- a/src/blender_mcp/bundled/addon.py
+++ b/src/blender_mcp/bundled/addon.py
@@ -54,6 +54,91 @@ RODIN_FREE_TRIAL_KEY = "vibecoding"
 REQ_HEADERS = requests.utils.default_headers()
 REQ_HEADERS.update({"User-Agent": "blender-mcp"})
 
+# Set when the user disconnects so opening another blend file does not restart
+# the server behind their back. A manual connect or add-on reload clears it.
+_user_stopped_server = False
+
+
+def _blendermcp_port_has_listener(host, port):
+    """Return True when another process already owns the MCP endpoint."""
+    probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    probe.settimeout(0.15)
+    try:
+        return probe.connect_ex((host, port)) == 0
+    finally:
+        probe.close()
+
+
+def _blendermcp_ensure_server_running():
+    """Start the bridge after Blender's UI and scene context are ready.
+
+    Returning a delay asks Blender's timer system to retry when a launch-time
+    socket or context race prevented the first attempt.
+    """
+    if bpy.app.background:
+        return None
+
+    scene = getattr(bpy.context, "scene", None)
+    if scene is None:
+        return 0.5
+
+    server = getattr(bpy.types, "blendermcp_server", None)
+    if not scene.blendermcp_auto_start_server or _user_stopped_server:
+        scene.blendermcp_server_running = bool(server is not None and server.running)
+        return None
+
+    port = scene.blendermcp_port
+    if server is None:
+        if _blendermcp_port_has_listener("localhost", port):
+            scene.blendermcp_server_running = False
+            print(f"BlenderMCP: port {port} is already in use; auto-start skipped.")
+            return None
+        server = BlenderMCPServer(port=port)
+        bpy.types.blendermcp_server = server
+
+    if not server.running:
+        # Safe while stopped and necessary when a newly loaded scene selects a
+        # different port. Never retarget an active connection.
+        server.port = port
+        server.start()
+
+    scene.blendermcp_server_running = server.running
+
+    return None if server.running else 1.0
+
+
+def _blendermcp_schedule_auto_start(delay=0.5):
+    """Schedule one persistent startup callback if none is already pending."""
+    if not bpy.app.timers.is_registered(_blendermcp_ensure_server_running):
+        bpy.app.timers.register(
+            _blendermcp_ensure_server_running,
+            first_interval=delay,
+            persistent=True,
+        )
+
+
+@persistent
+def _blendermcp_load_post(_unused):
+    """Retry auto-start after Blender loads a startup file or another blend."""
+    _blendermcp_schedule_auto_start()
+
+
+def _blendermcp_register_auto_start():
+    """Install the load handler and defer the initial startup attempt."""
+    global _user_stopped_server
+    _user_stopped_server = False
+    if _blendermcp_load_post not in bpy.app.handlers.load_post:
+        bpy.app.handlers.load_post.append(_blendermcp_load_post)
+    _blendermcp_schedule_auto_start()
+
+
+def _blendermcp_unregister_auto_start():
+    """Remove callbacks owned by the add-on before it is disabled."""
+    if _blendermcp_load_post in bpy.app.handlers.load_post:
+        bpy.app.handlers.load_post.remove(_blendermcp_load_post)
+    if bpy.app.timers.is_registered(_blendermcp_ensure_server_running):
+        bpy.app.timers.unregister(_blendermcp_ensure_server_running)
+
 #region Poly Pizza constants and helpers
 
 POLYPIZZA_API_BASE = "https://api.poly.pizza/v1.1"
@@ -3798,7 +3883,9 @@ class BLENDERMCP_PT_Panel(bpy.types.Panel):
         box = layout.box()
         col = box.column()
         if scene.blendermcp_server_running:
-            col.label(text=f"Connected on port {scene.blendermcp_port}", icon='CHECKMARK')
+            server = getattr(bpy.types, "blendermcp_server", None)
+            running_port = getattr(server, "port", scene.blendermcp_port)
+            col.label(text=f"Connected on port {running_port}", icon='CHECKMARK')
             col.operator("blendermcp.stop_server", text="Disconnect", icon='X')
         else:
             col.label(text="Not connected", icon='RADIOBUT_OFF')
@@ -3904,6 +3991,8 @@ class BLENDERMCP_OT_StartServer(bpy.types.Operator):
     bl_description = "Start the MCP for Blender server to connect with Claude"
 
     def execute(self, context):
+        global _user_stopped_server
+        _user_stopped_server = False
         scene = context.scene
 
         # Create a new server instance
@@ -3923,6 +4012,8 @@ class BLENDERMCP_OT_StopServer(bpy.types.Operator):
     bl_description = "Stop the connection to Claude"
 
     def execute(self, context):
+        global _user_stopped_server
+        _user_stopped_server = True
         scene = context.scene
 
         # Stop the server if it exists
@@ -4102,27 +4193,15 @@ def register():
     bpy.utils.register_class(BLENDERMCP_OT_StopServer)
     bpy.utils.register_class(BLENDERMCP_OT_OpenTerms)
 
-    # Auto-start the server so the MCP client can connect without manual UI interaction
-    scene = getattr(bpy.context, 'scene', None)
-    if scene is not None:
-        port = scene.blendermcp_port
-        auto_start = scene.blendermcp_auto_start_server
-    else:
-        port = 9876
-        auto_start = True
-
-    if auto_start and (not hasattr(bpy.types, "blendermcp_server") or not bpy.types.blendermcp_server):
-        bpy.types.blendermcp_server = BlenderMCPServer(port=port)
-    if auto_start and not bpy.types.blendermcp_server.running:
-        bpy.types.blendermcp_server.start()
-        try:
-            bpy.context.scene.blendermcp_server_running = bpy.types.blendermcp_server.running
-        except AttributeError:
-            pass
+    # Add-on registration can run before Blender has a stable UI/scene context.
+    # Defer socket startup and retry after startup-file or .blend loads.
+    _blendermcp_register_auto_start()
 
     print("BlenderMCP addon registered")
 
 def unregister():
+    _blendermcp_unregister_auto_start()
+
     _unregister_edit_capture_handlers()
 
     # Stop the server if it's running

--- a/tests/test_addon_autostart.py
+++ b/tests/test_addon_autostart.py
@@ -1,0 +1,216 @@
+"""Regression tests for the add-on's deferred socket auto-start lifecycle.
+
+The add-on cannot be imported without Blender, so the small auto-start helper
+functions are lifted out with AST and executed against a minimal bpy stub.
+"""
+
+from __future__ import annotations
+
+import ast
+import socket
+import types
+from typing import ClassVar
+
+from conftest import ROOT_ADDON
+
+_AUTOSTART_FUNCTIONS = {
+    "_blendermcp_port_has_listener",
+    "_blendermcp_ensure_server_running",
+    "_blendermcp_schedule_auto_start",
+    "_blendermcp_load_post",
+    "_blendermcp_register_auto_start",
+    "_blendermcp_unregister_auto_start",
+}
+
+
+class _Timers:
+    def __init__(self):
+        self.registrations = {}
+
+    def register(self, fn, first_interval=0.0, persistent=False):
+        self.registrations[fn] = {
+            "first_interval": first_interval,
+            "persistent": persistent,
+        }
+
+    def unregister(self, fn):
+        self.registrations.pop(fn)
+
+    def is_registered(self, fn):
+        return fn in self.registrations
+
+
+class _Server:
+    instances: ClassVar[list[_Server]] = []
+    failures_before_start = 0
+
+    def __init__(self, port):
+        self.port = port
+        self.running = False
+        self.start_attempts = 0
+        self.__class__.instances.append(self)
+
+    def start(self):
+        self.start_attempts += 1
+        if self.start_attempts > self.__class__.failures_before_start:
+            self.running = True
+
+
+def _load_autostart_helpers():
+    source = ROOT_ADDON.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    body = [
+        node
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name in _AUTOSTART_FUNCTIONS
+    ]
+    assert {node.name for node in body} == _AUTOSTART_FUNCTIONS
+
+    timers = _Timers()
+    scene = types.SimpleNamespace(
+        blendermcp_auto_start_server=True,
+        blendermcp_port=9876,
+        blendermcp_server_running=False,
+    )
+    bpy = types.SimpleNamespace(
+        app=types.SimpleNamespace(
+            background=False,
+            timers=timers,
+            handlers=types.SimpleNamespace(load_post=[]),
+        ),
+        context=types.SimpleNamespace(scene=scene),
+        types=types.SimpleNamespace(),
+    )
+    namespace = {
+        "bpy": bpy,
+        "socket": socket,
+        "persistent": lambda fn: fn,
+        "BlenderMCPServer": _Server,
+        "_user_stopped_server": False,
+    }
+    exec(  # noqa: S102 - execute only the selected functions from our own source.
+        compile(ast.Module(body=body, type_ignores=[]), "<addon>", "exec"), namespace
+    )
+    namespace["_blendermcp_port_has_listener"] = lambda host, port: False
+    return namespace, bpy, timers, scene
+
+
+def setup_function():
+    _Server.instances = []
+    _Server.failures_before_start = 0
+
+
+def test_registration_defers_start_and_is_idempotent():
+    namespace, bpy, timers, _scene = _load_autostart_helpers()
+    register_auto_start = namespace["_blendermcp_register_auto_start"]
+    ensure_running = namespace["_blendermcp_ensure_server_running"]
+    load_post = namespace["_blendermcp_load_post"]
+
+    register_auto_start()
+    register_auto_start()
+
+    assert _Server.instances == []
+    assert bpy.app.handlers.load_post == [load_post]
+    assert timers.registrations == {
+        ensure_running: {"first_interval": 0.5, "persistent": True}
+    }
+
+
+def test_timer_retries_a_failed_start_then_marks_scene_running():
+    namespace, bpy, _timers, scene = _load_autostart_helpers()
+    ensure_running = namespace["_blendermcp_ensure_server_running"]
+    _Server.failures_before_start = 1
+
+    assert ensure_running() == 1.0
+    server = bpy.types.blendermcp_server
+    assert server.start_attempts == 1
+    assert scene.blendermcp_server_running is False
+
+    assert ensure_running() is None
+    assert server.start_attempts == 2
+    assert scene.blendermcp_server_running is True
+
+
+def test_load_post_restores_a_missing_timer():
+    namespace, _bpy, timers, _scene = _load_autostart_helpers()
+    ensure_running = namespace["_blendermcp_ensure_server_running"]
+
+    namespace["_blendermcp_load_post"](None)
+
+    assert timers.is_registered(ensure_running)
+    assert timers.registrations[ensure_running]["persistent"] is True
+
+
+def test_disabled_auto_start_does_not_create_a_server():
+    namespace, _bpy, _timers, scene = _load_autostart_helpers()
+    scene.blendermcp_auto_start_server = False
+
+    assert namespace["_blendermcp_ensure_server_running"]() is None
+    assert _Server.instances == []
+
+
+def test_occupied_port_does_not_create_a_competing_server():
+    namespace, _bpy, _timers, scene = _load_autostart_helpers()
+    namespace["_blendermcp_port_has_listener"] = lambda host, port: True
+
+    assert namespace["_blendermcp_ensure_server_running"]() is None
+    assert _Server.instances == []
+    assert scene.blendermcp_server_running is False
+
+
+def test_background_mode_does_not_schedule_retries():
+    namespace, bpy, _timers, _scene = _load_autostart_helpers()
+    bpy.app.background = True
+
+    assert namespace["_blendermcp_ensure_server_running"]() is None
+    assert _Server.instances == []
+
+
+def test_missing_scene_retries_without_binding_the_default_port():
+    namespace, bpy, _timers, _scene = _load_autostart_helpers()
+    bpy.context.scene = None
+
+    assert namespace["_blendermcp_ensure_server_running"]() == 0.5
+    assert _Server.instances == []
+
+
+def test_stopped_server_retargets_to_the_loaded_scene_port():
+    namespace, bpy, _timers, scene = _load_autostart_helpers()
+    server = _Server(port=9876)
+    bpy.types.blendermcp_server = server
+    scene.blendermcp_port = 9999
+
+    assert namespace["_blendermcp_ensure_server_running"]() is None
+    assert server.port == 9999
+    assert server.running is True
+
+
+def test_manual_disconnect_survives_loading_another_file():
+    namespace, _bpy, _timers, scene = _load_autostart_helpers()
+    namespace["_user_stopped_server"] = True
+
+    assert namespace["_blendermcp_ensure_server_running"]() is None
+    assert _Server.instances == []
+    assert scene.blendermcp_server_running is False
+
+
+def test_registration_clears_manual_disconnect_for_an_addon_reload():
+    namespace, _bpy, _timers, _scene = _load_autostart_helpers()
+    namespace["_user_stopped_server"] = True
+
+    namespace["_blendermcp_register_auto_start"]()
+
+    assert namespace["_user_stopped_server"] is False
+
+
+def test_unregistration_removes_handler_and_pending_timer():
+    namespace, bpy, timers, _scene = _load_autostart_helpers()
+    register_auto_start = namespace["_blendermcp_register_auto_start"]
+    unregister_auto_start = namespace["_blendermcp_unregister_auto_start"]
+
+    register_auto_start()
+    unregister_auto_start()
+
+    assert bpy.app.handlers.load_post == []
+    assert timers.registrations == {}


### PR DESCRIPTION
## Problem

On a cold Blender launch, add-on registration can run before the UI and scene context are ready. Starting the socket synchronously from register() makes auto-start timing-dependent: an early failure is never retried, and scene-specific state such as the configured port and running flag can be missed.

## Fix

- defer startup through a persistent Blender timer
- wait until a scene exists, then use its configured port
- retry after a transient failed start
- reschedule after startup-file and blend-file loads
- keep an intentional manual disconnect from being undone by a later file load
- avoid competing with an existing listener on the configured port
- keep the panel status and displayed running port synchronized
- remove the load handler and pending timer during unregister()
- keep the root and bundled add-on copies identical

## Regression coverage

Added AST-based tests, requiring no Blender installation, for deferred/idempotent registration, missing-scene retry, transient startup retry, configured-port retargeting, load-post recovery, disabled auto-start, manual disconnect, occupied ports, background mode, add-on reload, and callback cleanup.

- 124 tests passed
- py_compile passed for both add-on copies and the new tests
- root and bundled addon.py copies compare byte-for-byte
- Blender 5.2 LTS smoke test confirmed handler/timer registration and clean unregister

PR #327 independently identified the related scene-port and panel-state symptoms. This PR is based on current main, preserves those useful behaviors, and adds timer-based retry and explicit lifecycle cleanup; #327 is currently conflicting with main.